### PR TITLE
fix hello world integration between backend and angular frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ relatorio-turno/
 ## 🎯 Funcionalidades
 
 - ✅ **Página inicial** com design moderno
-- ✅ **Endpoint `/api/hello`** que retorna "Olá Rafael"
+- ✅ **Endpoint `/api/hello`** que retorna "Hello World"
 - ✅ **Comunicação frontend-backend** via HTTP REST
 - ✅ **Hot reload** para desenvolvimento
 - ✅ **Interface responsiva** e amigável
@@ -82,7 +82,7 @@ Retorna uma mensagem de saudação personalizada.
 **Resposta:**
 ```json
 {
-  "message": "Olá Rafael",
+  "message": "Hello World",
   "timestamp": "2025-09-03T22:00:00.000Z",
   "backend": "Node.js + Express"
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,10 +16,10 @@ app.get('/', (req, res) => {
   res.json({ message: 'Backend Node.js + Express funcionando!' });
 });
 
-// Endpoint que retorna "Olá Rafael"
+// Endpoint que retorna "Hello World"
 app.get('/api/hello', (req, res) => {
   res.json({
-    message: 'Olá Rafael',
+    message: 'Hello World',
     timestamp: new Date().toISOString(),
     backend: 'Node.js + Express'
   });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,8 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
+    "moduleResolution": "node",
+    "types": [],
     "useDefineForClassFields": false,
     "lib": [
       "ES2022",


### PR DESCRIPTION
## Summary
- adjust backend `/api/hello` endpoint to return classic "Hello World" message
- configure Angular TypeScript to resolve modules correctly so the frontend builds
- update README to reflect the new greeting message

## Testing
- `node backend/src/server.js &` then `curl -s http://localhost:3000/api/hello; echo`
- `npm run dev:frontend`
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d659d008832585ba3b4d03bad823