### PR TITLE
feat: add report context controls to header

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { registerLocaleData } from '@angular/common';
 import localePt from '@angular/common/locales/pt';
+import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './layout/header/header.component';
@@ -26,6 +27,7 @@ registerLocaleData(localePt);
   imports: [
     BrowserModule,
     HttpClientModule,
+    FormsModule,
     AppRoutingModule
   ],
   providers: [{ provide: LOCALE_ID, useValue: 'pt-BR' }],

--- a/frontend/src/app/core/app-state.service.ts
+++ b/frontend/src/app/core/app-state.service.ts
@@ -1,10 +1,70 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface ReportContext {
+  area: string;
+  date: string; // ISO yyyy-mm-dd
+  shift: number; // 1,2 or 3
+}
 
 /**
- * Global application state placeholder.
- * Future items will expand this service with real state management.
+ * Global application state for report context.
+ * Maintains area, date and shift selections and keeps them in the URL.
  */
 @Injectable({ providedIn: 'root' })
 export class AppStateService {
-  // Placeholder for future global state (area, date, shift, etc.)
+  private contextSubject: BehaviorSubject<ReportContext>;
+  readonly context$;
+
+  constructor() {
+    const params = new URLSearchParams(window.location.search);
+    const initial: ReportContext = {
+      area: params.get('area') || 'Recebimento de Bauxita',
+      date: params.get('date') || this.todayIso(),
+      shift: this.parseShift(params.get('shift'))
+    };
+    this.contextSubject = new BehaviorSubject<ReportContext>(initial);
+    this.context$ = this.contextSubject.asObservable();
+    this.persist(initial);
+  }
+
+  get context(): ReportContext {
+    return this.contextSubject.value;
+  }
+
+  setArea(area: string): void {
+    this.update({ area });
+  }
+
+  setDate(date: string): void {
+    this.update({ date });
+  }
+
+  setShift(shift: number): void {
+    this.update({ shift: this.parseShift(String(shift)) });
+  }
+
+  private update(partial: Partial<ReportContext>): void {
+    const next = { ...this.contextSubject.value, ...partial };
+    this.contextSubject.next(next);
+    this.persist(next);
+  }
+
+  private persist(ctx: ReportContext): void {
+    const params = new URLSearchParams();
+    params.set('area', ctx.area);
+    params.set('date', ctx.date);
+    params.set('shift', String(ctx.shift));
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState({}, '', newUrl);
+  }
+
+  private todayIso(): string {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(new Date());
+  }
+
+  private parseShift(value: string | null): number {
+    const num = Number(value);
+    return num === 2 || num === 3 ? num : 1;
+  }
 }

--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+/**
+ * Provides the list of operational areas. Attempts to load from API and
+ * falls back to a static list when the backend is unavailable.
+ */
+@Injectable({ providedIn: 'root' })
+export class AreasService {
+  private readonly fallbackAreas: string[] = [
+    'Recebimento de Bauxita',
+    'Digestão',
+    'Clarificação',
+    'Filtro Prensa',
+    'Precipitação',
+    'Calcinação',
+    'Vapor e Utilidades',
+    'Águas e Efluentes',
+    'Automação e Energia',
+    'Porto',
+    'Meio Ambiente'
+  ];
+
+  constructor(private http: HttpClient) {}
+
+  /** Returns operational areas with graceful fallback. */
+  getAreas(): Observable<string[]> {
+    return this.http.get<string[]>('/api/areas').pipe(
+      map((areas) => (areas && areas.length ? areas : this.fallbackAreas)),
+      catchError(() => of(this.fallbackAreas))
+    );
+  }
+}

--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -1,9 +1,60 @@
 <header class="sticky top-0 z-10 bg-white dark:bg-gray-800 shadow-sm" role="banner">
-  <div class="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+  <div class="max-w-7xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4">
     <h1 class="text-xl font-semibold">Relatório de Turno</h1>
-    <div class="flex items-center space-x-4 text-gray-500 dark:text-gray-400" aria-label="Espaço para controles futuros">
-      <div class="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" aria-hidden="true"></div>
-      <span class="hidden sm:inline">Controles</span>
+    <div class="flex flex-wrap items-center gap-2 ml-auto text-sm">
+      <!-- Area selector -->
+      <label for="area" class="sr-only">Área</label>
+      <select
+        id="area"
+        class="border rounded px-2 py-1 bg-white dark:bg-gray-700"
+        [ngModel]="(context$ | async)?.area"
+        (ngModelChange)="onAreaChange($event)"
+      >
+        <option *ngFor="let area of areas" [value]="area">{{ area }}</option>
+      </select>
+
+      <!-- Date selector -->
+      <label for="date" class="sr-only">Data</label>
+      <input
+        id="date"
+        type="date"
+        class="border rounded px-2 py-1 bg-white dark:bg-gray-700"
+        [ngModel]="(context$ | async)?.date"
+        (ngModelChange)="onDateChange($event)"
+      />
+
+      <!-- Shift selector -->
+      <div role="group" aria-label="Turno" class="flex border rounded overflow-hidden">
+        <button
+          *ngFor="let s of [1,2,3]"
+          type="button"
+          (click)="onShiftChange(s)"
+          [class.bg-blue-600]="(context$ | async)?.shift === s"
+          [class.text-white]="(context$ | async)?.shift === s"
+          class="px-2 py-1 focus:outline-none focus:ring"
+        >
+          {{ s }}
+        </button>
+      </div>
+
+      <!-- Export PDF -->
+      <button
+        type="button"
+        (click)="exportPdf()"
+        class="px-3 py-1 border rounded hover:bg-gray-100 focus:outline-none focus:ring"
+        aria-label="Exportar PDF"
+      >
+        Exportar PDF
+      </button>
+
+      <!-- User placeholder -->
+      <div
+        class="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-gray-600"
+        aria-label="Usuário"
+      >
+        <span class="text-sm">U</span>
+      </div>
     </div>
   </div>
+  <div *ngIf="exportMessage" class="text-center text-sm text-gray-600 py-1">{{ exportMessage }}</div>
 </header>

--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -1,8 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { AppStateService } from '../../core/app-state.service';
+import { AreasService } from '../../core/areas.service';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })
-export class HeaderComponent {}
+export class HeaderComponent implements OnInit {
+  areas: string[] = [];
+  exportMessage = '';
+  readonly context$ = this.appState.context$;
+
+  constructor(private appState: AppStateService, private areasService: AreasService) {}
+
+  ngOnInit(): void {
+    this.areasService.getAreas().subscribe((areas) => (this.areas = areas));
+  }
+
+  onAreaChange(area: string): void {
+    this.appState.setArea(area);
+  }
+
+  onDateChange(date: string): void {
+    this.appState.setDate(date);
+  }
+
+  onShiftChange(shift: number): void {
+    this.appState.setShift(shift);
+  }
+
+  exportPdf(): void {
+    this.exportMessage = 'Exportação de PDF ainda não disponível.';
+    setTimeout(() => (this.exportMessage = ''), 3000);
+  }
+}

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -1,5 +1,6 @@
 <div class="max-w-7xl mx-auto px-4 py-8 space-y-8">
   <h2 class="text-2xl font-semibold">Relatório de Turno — estrutura base pronta</h2>
+  <p *ngIf="context$ | async as ctx" class="text-gray-600">{{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}</p>
 
   <section id="composer" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
     <h3 class="text-lg font-semibold mb-2">Composer</h3>

--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -1,8 +1,14 @@
 import { Component } from '@angular/core';
+import { AppStateService, ReportContext } from '../../core/app-state.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-report',
   templateUrl: './report.component.html',
   styleUrls: ['./report.component.css']
 })
-export class ReportComponent {}
+export class ReportComponent {
+  readonly context$: Observable<ReportContext> = this.appState.context$;
+
+  constructor(private appState: AppStateService) {}
+}


### PR DESCRIPTION
## Summary
- add global report context state synchronized with URL
- implement area provider with API fallback
- wire header controls and PDF export stub; display context on report page

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ffff3f08325a3a9ff2ed2d9790f