### PR TITLE
feat: add core MVP data model and API

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,9 @@
         "@prisma/client": "^6.15.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "multer": "^2.0.2",
+        "sanitize-html": "^2.17.0"
       },
       "devDependencies": {
         "nodemon": "^3.0.1",
@@ -136,6 +138,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -202,6 +210,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -351,6 +376,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
@@ -420,6 +460,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -459,6 +508,61 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -520,6 +624,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -551,6 +667,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -809,6 +937,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -896,6 +1043,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
@@ -980,10 +1136,67 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -1117,6 +1330,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1144,6 +1363,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1166,6 +1391,34 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prisma": {
@@ -1276,6 +1529,20 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1311,6 +1578,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -1459,12 +1740,38 @@
         "node": ">=10"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/supports-color": {
@@ -1527,6 +1834,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -1540,6 +1853,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1555,6 +1874,15 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,9 @@
     "@prisma/client": "^6.15.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "multer": "^2.0.2",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1",

--- a/backend/prisma/migrations/20241015000000_mvp_models/migration.sql
+++ b/backend/prisma/migrations/20241015000000_mvp_models/migration.sql
@@ -1,0 +1,81 @@
+-- CreateEnum
+CREATE TYPE "PostType" AS ENUM ('ANNOTATION','URGENCY','PENDENCY');
+
+-- CreateTable Area
+CREATE TABLE "Area" (
+  "id" SERIAL PRIMARY KEY,
+  "name" TEXT NOT NULL
+);
+
+-- CreateTable User
+CREATE TABLE "User" (
+  "id" SERIAL PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "email" TEXT NOT NULL UNIQUE,
+  "role" TEXT NOT NULL,
+  "avatar" TEXT
+);
+
+-- CreateTable Post
+CREATE TABLE "Post" (
+  "id" SERIAL PRIMARY KEY,
+  "areaId" INTEGER NOT NULL REFERENCES "Area"("id"),
+  "date" DATE NOT NULL,
+  "shift" INTEGER NOT NULL,
+  "type" "PostType" NOT NULL,
+  "content" TEXT NOT NULL,
+  "authorId" INTEGER NOT NULL REFERENCES "User"("id"),
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable Reply
+CREATE TABLE "Reply" (
+  "id" SERIAL PRIMARY KEY,
+  "postId" INTEGER NOT NULL REFERENCES "Post"("id"),
+  "authorId" INTEGER NOT NULL REFERENCES "User"("id"),
+  "content" TEXT NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable Attachment
+CREATE TABLE "Attachment" (
+  "id" SERIAL PRIMARY KEY,
+  "postId" INTEGER REFERENCES "Post"("id"),
+  "replyId" INTEGER REFERENCES "Reply"("id"),
+  "filename" TEXT NOT NULL,
+  "mimeType" TEXT NOT NULL,
+  "size" INTEGER NOT NULL,
+  "url" TEXT NOT NULL
+);
+
+-- CreateTable Indicator
+CREATE TABLE "Indicator" (
+  "id" SERIAL PRIMARY KEY,
+  "areaId" INTEGER NOT NULL REFERENCES "Area"("id"),
+  "code" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "unit" TEXT NOT NULL,
+  "target" DOUBLE PRECISION
+);
+
+-- CreateTable IndicatorValue
+CREATE TABLE "IndicatorValue" (
+  "id" SERIAL PRIMARY KEY,
+  "indicatorId" INTEGER NOT NULL REFERENCES "Indicator"("id"),
+  "areaId" INTEGER NOT NULL REFERENCES "Area"("id"),
+  "date" DATE NOT NULL,
+  "shift" INTEGER NOT NULL,
+  "value" DOUBLE PRECISION NOT NULL,
+  "source" TEXT NOT NULL
+);
+
+-- CreateTable AuditLog
+CREATE TABLE "AuditLog" (
+  "id" SERIAL PRIMARY KEY,
+  "userId" INTEGER NOT NULL REFERENCES "User"("id"),
+  "action" TEXT NOT NULL,
+  "targetType" TEXT NOT NULL,
+  "targetId" INTEGER,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,3 +18,100 @@ model Report {
   createdAt DateTime @default(now())
   content   String
 }
+
+enum PostType {
+  ANNOTATION
+  URGENCY
+  PENDENCY
+}
+
+model Area {
+  id        Int      @id @default(autoincrement())
+  name      String
+  posts     Post[]
+  indicators Indicator[]
+  indicatorValues IndicatorValue[]
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  role      String
+  avatar    String?
+  posts     Post[]
+  replies   Reply[]
+  auditLogs AuditLog[]
+}
+
+model Post {
+  id        Int       @id @default(autoincrement())
+  area      Area      @relation(fields: [areaId], references: [id])
+  areaId    Int
+  date      DateTime
+  shift     Int
+  type      PostType
+  content   String
+  author    User      @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  attachments Attachment[]
+  replies    Reply[]
+}
+
+model Reply {
+  id        Int       @id @default(autoincrement())
+  post      Post      @relation(fields: [postId], references: [id])
+  postId    Int
+  author    User      @relation(fields: [authorId], references: [id])
+  authorId  Int
+  content   String
+  createdAt DateTime  @default(now())
+  attachments Attachment[]
+}
+
+model Attachment {
+  id        Int      @id @default(autoincrement())
+  post      Post?    @relation(fields: [postId], references: [id])
+  postId    Int?
+  reply     Reply?   @relation(fields: [replyId], references: [id])
+  replyId   Int?
+  filename  String
+  mimeType  String
+  size      Int
+  url       String
+}
+
+model Indicator {
+  id        Int      @id @default(autoincrement())
+  area      Area     @relation(fields: [areaId], references: [id])
+  areaId    Int
+  code      String
+  name      String
+  unit      String
+  target    Float?
+  values    IndicatorValue[]
+}
+
+model IndicatorValue {
+  id          Int       @id @default(autoincrement())
+  indicator   Indicator @relation(fields: [indicatorId], references: [id])
+  indicatorId Int
+  area        Area      @relation(fields: [areaId], references: [id])
+  areaId      Int
+  date        DateTime
+  shift       Int
+  value       Float
+  source      String
+}
+
+model AuditLog {
+  id         Int      @id @default(autoincrement())
+  user       User     @relation(fields: [userId], references: [id])
+  userId     Int
+  action     String
+  targetType String
+  targetId   Int?
+  createdAt  DateTime @default(now())
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,11 +1,48 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
+const fs = require('fs');
+const multer = require('multer');
+const sanitizeHtml = require('sanitize-html');
 const { PrismaClient } = require('@prisma/client');
 
 const prisma = new PrismaClient();
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// ensure upload directory exists
+const uploadDir = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const upload = multer({
+  dest: uploadDir,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB
+  fileFilter: (req, file, cb) => {
+    const allowed = ['image/png', 'image/jpeg', 'application/pdf'];
+    if (allowed.includes(file.mimetype)) cb(null, true);
+    else cb(new Error('Invalid file type'));
+  },
+});
+
+function parseDate(dateStr) {
+  return new Date(`${dateStr}T00:00:00-03:00`);
+}
+
+async function ensureUser(id) {
+  return prisma.user.upsert({
+    where: { id },
+    update: {},
+    create: {
+      id,
+      name: `User ${id}`,
+      email: `user${id}@example.com`,
+      role: 'OPERATOR',
+    },
+  });
+}
 
 (async () => {
   try {
@@ -23,6 +60,7 @@ app.use(cors({
   credentials: true
 }));
 app.use(express.json());
+app.use('/uploads', express.static(uploadDir));
 
 // Rota raiz
 app.get('/', (req, res) => {
@@ -46,6 +84,203 @@ app.get('/api/reports', async (req, res) => {
   } catch (error) {
     res.status(500).json({ error: 'Erro ao buscar relatórios' });
   }
+});
+
+// ----- Areas -----
+app.get('/api/areas', async (req, res) => {
+  const areas = await prisma.area.findMany();
+  res.json(areas);
+});
+
+// ----- Profile -----
+app.get('/api/me', async (req, res) => {
+  const userId = Number(req.header('x-user-id')) || 1;
+  const user = await ensureUser(userId);
+  res.json({ id: user.id, name: user.name, avatar: user.avatar, role: user.role });
+});
+
+// ----- Posts -----
+app.post('/api/posts', upload.array('attachments'), async (req, res) => {
+  try {
+    const userId = Number(req.header('x-user-id')) || 1;
+    const user = await ensureUser(userId);
+    const { areaId, date, shift, type, content } = req.body;
+    const sanitized = sanitizeHtml(content || '');
+    const post = await prisma.post.create({
+      data: {
+        areaId: Number(areaId),
+        date: parseDate(date),
+        shift: Number(shift),
+        type,
+        content: sanitized,
+        authorId: user.id,
+      },
+    });
+
+    if (req.files && req.files.length) {
+      const attachmentsData = req.files.map((f) => ({
+        postId: post.id,
+        filename: f.originalname,
+        mimeType: f.mimetype,
+        size: f.size,
+        url: `/uploads/${f.filename}`,
+      }));
+      await prisma.attachment.createMany({ data: attachmentsData });
+    }
+
+    await prisma.auditLog.create({
+      data: {
+        userId: user.id,
+        action: 'CREATE_POST',
+        targetType: 'Post',
+        targetId: post.id,
+      },
+    });
+
+    const fullPost = await prisma.post.findUnique({
+      where: { id: post.id },
+      include: { attachments: true },
+    });
+    res.status(201).json(fullPost);
+  } catch (error) {
+    res.status(400).json({ error: 'Failed to create post' });
+  }
+});
+
+app.get('/api/posts', async (req, res) => {
+  const { areaId, date, shift, type, page = 1, pageSize = 10 } = req.query;
+  const filters = {};
+  if (areaId) filters.areaId = Number(areaId);
+  if (date) filters.date = parseDate(date);
+  if (shift) filters.shift = Number(shift);
+  if (type) filters.type = type;
+  const posts = await prisma.post.findMany({
+    where: filters,
+    orderBy: { createdAt: 'desc' },
+    skip: (Number(page) - 1) * Number(pageSize),
+    take: Number(pageSize),
+    include: { attachments: true },
+  });
+  res.json(posts);
+});
+
+app.get('/api/posts/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const post = await prisma.post.findUnique({
+    where: { id },
+    include: { attachments: true, replies: { include: { attachments: true } } },
+  });
+  if (!post) return res.status(404).json({ error: 'Post not found' });
+  res.json(post);
+});
+
+// ----- Replies -----
+app.post('/api/posts/:id/replies', upload.array('attachments'), async (req, res) => {
+  try {
+    const postId = Number(req.params.id);
+    const userId = Number(req.header('x-user-id')) || 1;
+    const user = await ensureUser(userId);
+    const sanitized = sanitizeHtml(req.body.content || '');
+    const reply = await prisma.reply.create({
+      data: {
+        postId,
+        authorId: user.id,
+        content: sanitized,
+      },
+    });
+
+    if (req.files && req.files.length) {
+      const attData = req.files.map((f) => ({
+        replyId: reply.id,
+        filename: f.originalname,
+        mimeType: f.mimetype,
+        size: f.size,
+        url: `/uploads/${f.filename}`,
+      }));
+      await prisma.attachment.createMany({ data: attData });
+    }
+
+    await prisma.auditLog.create({
+      data: {
+        userId: user.id,
+        action: 'CREATE_REPLY',
+        targetType: 'Reply',
+        targetId: reply.id,
+      },
+    });
+
+    const fullReply = await prisma.reply.findUnique({
+      where: { id: reply.id },
+      include: { attachments: true },
+    });
+    res.status(201).json(fullReply);
+  } catch (error) {
+    res.status(400).json({ error: 'Failed to create reply' });
+  }
+});
+
+app.get('/api/posts/:id/replies', async (req, res) => {
+  const postId = Number(req.params.id);
+  const replies = await prisma.reply.findMany({
+    where: { postId },
+    orderBy: { createdAt: 'asc' },
+    include: { attachments: true },
+  });
+  res.json(replies);
+});
+
+// ----- Indicators -----
+app.get('/api/areas/:areaId/indicators', async (req, res) => {
+  const areaId = Number(req.params.areaId);
+  const indicators = await prisma.indicator.findMany({ where: { areaId } });
+  res.json(indicators);
+});
+
+app.get('/api/indicator-values', async (req, res) => {
+  const { areaId, date, shift } = req.query;
+  const area = Number(areaId);
+  const d = parseDate(date);
+  const s = Number(shift);
+  const values = await prisma.indicatorValue.findMany({
+    where: { areaId: area, date: d, shift: s },
+    include: { indicator: true },
+  });
+  if (values.length === 0) {
+    const indicators = await prisma.indicator.findMany({ where: { areaId: area } });
+    const mock = indicators.map((ind) => ({
+      indicator: ind,
+      value: 0,
+      source: 'mock',
+    }));
+    return res.json(mock);
+  }
+  res.json(values);
+});
+
+// ----- Summary -----
+app.get('/api/summary', async (req, res) => {
+  const { areaId, date, shift } = req.query;
+  const area = Number(areaId);
+  const d = parseDate(date);
+  const s = Number(shift);
+  const counts = await prisma.post.groupBy({
+    where: { areaId: area, date: d, shift: s },
+    by: ['type'],
+    _count: { _all: true },
+  });
+  res.json(counts);
+});
+
+// ----- Export -----
+app.post('/api/export', async (req, res) => {
+  const { areaId, date, shift } = req.body;
+  res.json({
+    status: 'queued',
+    areaId: Number(areaId),
+    date,
+    shift: Number(shift),
+    message: 'PDF export not implemented in MVP',
+  });
 });
 
 // Inicializa o servidor


### PR DESCRIPTION
## Summary
- define persistent models for areas, users, posts, attachments, replies, indicators, indicator values, and audit logs
- implement REST endpoints for areas, profile, posts, replies, indicators, summaries, and PDF export trigger
- add sanitization and basic file upload handling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `npx prisma validate`


------
https://chatgpt.com/codex/tasks/task_e_68b9a30e07b08325bf0fecce37e04b8d