### PR TITLE
feat: add post composer with attachments

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^16.2.0",
         "@angular/platform-browser-dynamic": "^16.2.0",
         "@angular/router": "^16.2.0",
+        "dompurify": "^3.2.6",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.0"
@@ -24,6 +25,7 @@
         "@angular-devkit/build-angular": "^16.2.0",
         "@angular/cli": "^16.2.0",
         "@angular/compiler-cli": "^16.2.0",
+        "@types/dompurify": "^3.0.5",
         "@types/jasmine": "~4.3.0",
         "autoprefixer": "^10.4.14",
         "jasmine-core": "~4.6.0",
@@ -3534,6 +3536,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3683,6 +3695,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5594,6 +5613,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
+    "dompurify": "^3.2.6",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"
@@ -26,6 +27,7 @@
     "@angular-devkit/build-angular": "^16.2.0",
     "@angular/cli": "^16.2.0",
     "@angular/compiler-cli": "^16.2.0",
+    "@types/dompurify": "^3.0.5",
     "@types/jasmine": "~4.3.0",
     "autoprefixer": "^10.4.14",
     "jasmine-core": "~4.6.0",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AppComponent } from './app.component';
 import { HeaderComponent } from './layout/header/header.component';
 import { FooterComponent } from './layout/footer/footer.component';
 import { ReportComponent } from './pages/report/report.component';
+import { PostComposerComponent } from './pages/report/post-composer/post-composer.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -21,6 +22,7 @@ registerLocaleData(localePt);
     HeaderComponent,
     FooterComponent,
     ReportComponent,
+    PostComposerComponent,
     AdminComponent,
     NotFoundComponent
   ],

--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -3,33 +3,43 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
+export interface Area {
+  id: number;
+  name: string;
+}
+
 /**
  * Provides the list of operational areas. Attempts to load from API and
  * falls back to a static list when the backend is unavailable.
  */
 @Injectable({ providedIn: 'root' })
 export class AreasService {
-  private readonly fallbackAreas: string[] = [
-    'Recebimento de Bauxita',
-    'Digestão',
-    'Clarificação',
-    'Filtro Prensa',
-    'Precipitação',
-    'Calcinação',
-    'Vapor e Utilidades',
-    'Águas e Efluentes',
-    'Automação e Energia',
-    'Porto',
-    'Meio Ambiente'
+  private readonly fallbackAreas: Area[] = [
+    { id: 1, name: 'Recebimento de Bauxita' },
+    { id: 2, name: 'Digestão' },
+    { id: 3, name: 'Clarificação' },
+    { id: 4, name: 'Filtro Prensa' },
+    { id: 5, name: 'Precipitação' },
+    { id: 6, name: 'Calcinação' },
+    { id: 7, name: 'Vapor e Utilidades' },
+    { id: 8, name: 'Águas e Efluentes' },
+    { id: 9, name: 'Automação e Energia' },
+    { id: 10, name: 'Porto' },
+    { id: 11, name: 'Meio Ambiente' }
   ];
 
   constructor(private http: HttpClient) {}
 
-  /** Returns operational areas with graceful fallback. */
-  getAreas(): Observable<string[]> {
-    return this.http.get<string[]>('/api/areas').pipe(
+  /** Returns areas with id and name, using fallback data when API fails. */
+  getAreasWithIds(): Observable<Area[]> {
+    return this.http.get<Area[]>('/api/areas').pipe(
       map((areas) => (areas && areas.length ? areas : this.fallbackAreas)),
       catchError(() => of(this.fallbackAreas))
     );
+  }
+
+  /** Returns only area names with graceful fallback. */
+  getAreas(): Observable<string[]> {
+    return this.getAreasWithIds().pipe(map((areas) => areas.map((a) => a.name)));
   }
 }

--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+export type PostType = 'ANNOTATION' | 'URGENCY' | 'PENDENCY';
+
+export interface PostCreate {
+  areaId: number;
+  date: string;
+  shift: number;
+  type: PostType;
+  content: string;
+  attachments: File[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class PostsService {
+  private createdSource = new Subject<any>();
+  /** Emits newly created posts so that lists can refresh. */
+  readonly created$ = this.createdSource.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  /** Sends a new post to the backend API. */
+  create(payload: PostCreate): Observable<any> {
+    const form = new FormData();
+    form.append('areaId', String(payload.areaId));
+    form.append('date', payload.date);
+    form.append('shift', String(payload.shift));
+    form.append('type', payload.type);
+    form.append('content', payload.content);
+    for (const file of payload.attachments) {
+      form.append('attachments', file);
+    }
+    return this.http.post<any>('/api/posts', form).pipe(
+      tap((post) => this.createdSource.next(post))
+    );
+  }
+}

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.css
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.css
@@ -1,0 +1,4 @@
+.editor:empty::before {
+  content: attr(data-placeholder);
+  color: #6b7280; /* gray-500 */
+}

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -1,0 +1,64 @@
+<div
+  class="p-4 border border-gray-300 dark:border-gray-700 rounded space-y-4"
+  (drop)="onDrop($event)"
+  (dragover)="$event.preventDefault()"
+>
+  <div class="flex gap-4">
+    <label class="flex items-center gap-1">
+      <input type="radio" name="type" [(ngModel)]="type" value="ANNOTATION" (ngModelChange)="saveDraft()" />
+      <span>Anotação</span>
+    </label>
+    <label class="flex items-center gap-1">
+      <input type="radio" name="type" [(ngModel)]="type" value="URGENCY" (ngModelChange)="saveDraft()" />
+      <span>Urgência</span>
+    </label>
+    <label class="flex items-center gap-1">
+      <input type="radio" name="type" [(ngModel)]="type" value="PENDENCY" (ngModelChange)="saveDraft()" />
+      <span>Pendência</span>
+    </label>
+  </div>
+
+  <div class="border rounded">
+    <div class="flex gap-1 border-b p-1">
+      <button type="button" (click)="format('bold')" aria-label="Negrito" class="px-2 py-1 hover:bg-gray-100">B</button>
+      <button type="button" (click)="format('italic')" aria-label="Itálico" class="px-2 py-1 hover:bg-gray-100"><em>I</em></button>
+      <button type="button" (click)="format('insertUnorderedList')" aria-label="Lista" class="px-2 py-1 hover:bg-gray-100">•</button>
+      <button type="button" (click)="format('insertOrderedList')" aria-label="Lista numerada" class="px-2 py-1 hover:bg-gray-100">1.</button>
+      <button type="button" (click)="formatLink()" aria-label="Link" class="px-2 py-1 hover:bg-gray-100">🔗</button>
+    </div>
+    <div
+      #editor
+      class="editor p-2 min-h-[120px] outline-none"
+      contenteditable="true"
+      role="textbox"
+      aria-label="Conteúdo"
+      data-placeholder="Escreva uma atualização do turno..."
+      (input)="saveDraft()"
+      (paste)="onPaste($event)"
+    ></div>
+  </div>
+
+  <div *ngIf="attachments.length" class="space-y-2">
+    <div *ngFor="let att of attachments" class="flex items-center gap-2">
+      <img *ngIf="att.url" [src]="att.url" alt="Pré-visualização" class="w-16 h-16 object-cover rounded" />
+      <span class="text-sm">{{ att.file.name }} ({{ att.file.size / 1024 | number:'1.0-0' }} KB)</span>
+      <button type="button" (click)="removeAttachment(att)" class="text-red-600 text-sm">Remover</button>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <label class="cursor-pointer text-blue-600 flex items-center gap-1">
+      <input type="file" multiple class="hidden" (change)="onFileInput($event)" />
+      <span>Anexar arquivos</span>
+    </label>
+    <button
+      type="button"
+      (click)="publish()"
+      [disabled]="sending"
+      class="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+    >
+      {{ sending ? 'Publicando…' : 'Publicar' }}
+    </button>
+    <span *ngIf="message" class="text-sm" [class.text-red-600]="message.startsWith('Falha')" [class.text-green-600]="message.startsWith('Publicação')" >{{ message }}</span>
+  </div>
+</div>

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -1,0 +1,167 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { AppStateService, ReportContext } from '../../../core/app-state.service';
+import { AreasService, Area } from '../../../core/areas.service';
+import { PostsService, PostType } from '../../../core/posts.service';
+import DOMPurify from 'dompurify';
+
+interface AttachmentView {
+  file: File;
+  url?: string;
+  error?: string;
+}
+
+@Component({
+  selector: 'app-post-composer',
+  templateUrl: './post-composer.component.html',
+  styleUrls: ['./post-composer.component.css']
+})
+export class PostComposerComponent implements OnInit {
+  @ViewChild('editor') editor!: ElementRef<HTMLDivElement>;
+
+  ctx!: ReportContext;
+  areas: Area[] = [];
+  type: PostType = 'ANNOTATION';
+  attachments: AttachmentView[] = [];
+  message = '';
+  sending = false;
+
+  private readonly draftKey = 'post-draft';
+
+  constructor(
+    private appState: AppStateService,
+    private areasService: AreasService,
+    private posts: PostsService
+  ) {}
+
+  ngOnInit(): void {
+    this.appState.context$.subscribe((c) => (this.ctx = c));
+    this.areasService.getAreasWithIds().subscribe((areas) => (this.areas = areas));
+    this.restoreDraft();
+  }
+
+  format(cmd: string): void {
+    document.execCommand(cmd, false);
+  }
+
+  formatLink(): void {
+    const url = prompt('URL');
+    if (url) document.execCommand('createLink', false, url);
+  }
+
+  onFileInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files) {
+      this.addFiles(Array.from(input.files));
+    }
+  }
+
+  onDrop(evt: DragEvent): void {
+    evt.preventDefault();
+    if (evt.dataTransfer) {
+      this.addFiles(Array.from(evt.dataTransfer.files));
+    }
+  }
+
+  onPaste(evt: ClipboardEvent): void {
+    const items = evt.clipboardData?.files;
+    if (items && items.length) {
+      this.addFiles(Array.from(items));
+    }
+  }
+
+  private addFiles(files: File[]): void {
+    for (const file of files) {
+      const total = this.attachments.reduce((sum, a) => sum + a.file.size, 0);
+      if (file.size > 20 * 1024 * 1024) {
+        this.message = `Arquivo muito grande: ${file.name}`;
+        continue;
+      }
+      if (total + file.size > 50 * 1024 * 1024) {
+        this.message = 'Limite total de anexos excedido';
+        break;
+      }
+      if (!['image/png', 'image/jpeg', 'application/pdf'].includes(file.type)) {
+        this.message = `Tipo de arquivo não suportado: ${file.name}`;
+        continue;
+      }
+      const view: AttachmentView = { file };
+      if (file.type.startsWith('image/')) {
+        view.url = URL.createObjectURL(file);
+      }
+      this.attachments.push(view);
+    }
+  }
+
+  removeAttachment(att: AttachmentView): void {
+    this.attachments = this.attachments.filter((a) => a !== att);
+  }
+
+  async publish(): Promise<void> {
+    if (!this.ctx.area || !this.ctx.date || !this.ctx.shift) {
+      this.message = 'Defina área, data e turno para publicar.';
+      return;
+    }
+    const area = this.areas.find((a) => a.name === this.ctx.area);
+    if (!area) {
+      this.message = 'Área inválida.';
+      return;
+    }
+    const html = this.editor.nativeElement.innerHTML.trim();
+    if (!html) {
+      this.message = 'Conteúdo vazio.';
+      return;
+    }
+    const sanitized = DOMPurify.sanitize(html);
+    this.sending = true;
+    this.message = '';
+    this.saveDraft();
+    this.posts
+      .create({
+        areaId: area.id,
+        date: this.ctx.date,
+        shift: this.ctx.shift,
+        type: this.type,
+        content: sanitized,
+        attachments: this.attachments.map((a) => a.file),
+      })
+      .subscribe({
+        next: () => {
+          this.message = 'Publicação criada.';
+          this.editor.nativeElement.innerHTML = '';
+          this.type = 'ANNOTATION';
+          this.attachments = [];
+          this.clearDraft();
+          this.sending = false;
+        },
+        error: () => {
+          this.message = 'Falha ao publicar.';
+          this.sending = false;
+        },
+      });
+  }
+
+  saveDraft(): void {
+    const html = this.editor?.nativeElement?.innerHTML || '';
+    const draft = { type: this.type, content: html };
+    localStorage.setItem(this.draftKey, JSON.stringify(draft));
+  }
+
+  restoreDraft(): void {
+    const raw = localStorage.getItem(this.draftKey);
+    if (raw) {
+      try {
+        const draft = JSON.parse(raw);
+        this.type = draft.type || 'ANNOTATION';
+        setTimeout(() => {
+          if (this.editor) this.editor.nativeElement.innerHTML = draft.content || '';
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  clearDraft(): void {
+    localStorage.removeItem(this.draftKey);
+  }
+}

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -2,9 +2,8 @@
   <h2 class="text-2xl font-semibold">Relatório de Turno — estrutura base pronta</h2>
   <p *ngIf="context$ | async as ctx" class="text-gray-600">{{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}</p>
 
-  <section id="composer" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
-    <h3 class="text-lg font-semibold mb-2">Composer</h3>
-    <p class="text-gray-500 dark:text-gray-400">Placeholder</p>
+  <section id="composer">
+    <app-post-composer></app-post-composer>
   </section>
 
   <section id="area-indicators" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,8 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
- implement post composer with rich text, attachments, and draft persistence
- expose area identifiers and post API service
- wire composer into report page and module

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6ef3a8c832595ee2ce6f5ec668b