### PR TITLE
Handle duplicate attachments and sanitize filenames

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -31,6 +31,11 @@ function parseDate(dateStr) {
   return new Date(`${dateStr}T00:00:00-03:00`);
 }
 
+// Replace potentially dangerous characters from original file names.
+function sanitizeFilename(name) {
+  return path.basename(name).replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
 async function ensureUser(id) {
   return prisma.user.upsert({
     where: { id },
@@ -120,7 +125,7 @@ app.post('/api/posts', upload.array('attachments'), async (req, res) => {
     if (req.files && req.files.length) {
       const attachmentsData = req.files.map((f) => ({
         postId: post.id,
-        filename: f.originalname,
+        filename: sanitizeFilename(f.originalname),
         mimeType: f.mimetype,
         size: f.size,
         url: `/uploads/${f.filename}`,
@@ -192,7 +197,7 @@ app.post('/api/posts/:id/replies', upload.array('attachments'), async (req, res)
     if (req.files && req.files.length) {
       const attData = req.files.map((f) => ({
         replyId: reply.id,
-        filename: f.originalname,
+        filename: sanitizeFilename(f.originalname),
         mimeType: f.mimetype,
         size: f.size,
         url: `/uploads/${f.filename}`,

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -84,6 +84,13 @@ export class PostComposerComponent implements OnInit {
         this.message = `Tipo de arquivo não suportado: ${file.name}`;
         continue;
       }
+      const exists = this.attachments.some(
+        (a) => a.file.name === file.name && a.file.size === file.size
+      );
+      if (exists) {
+        this.message = `Arquivo duplicado ignorado: ${file.name}`;
+        continue;
+      }
       const view: AttachmentView = { file };
       if (file.type.startsWith('image/')) {
         view.url = URL.createObjectURL(file);


### PR DESCRIPTION
## Summary
- Sanitize uploaded filenames on the server to drop unsafe characters
- Ignore duplicate files in the post composer to avoid repeated uploads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test -- --watch=false` *(fails: Cannot find module 'dompurify')*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa18acd8832585456cf6a7df2e16