### PR TITLE
feat: show area indicators with mock data

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { HeaderComponent } from './layout/header/header.component';
 import { FooterComponent } from './layout/footer/footer.component';
 import { ReportComponent } from './pages/report/report.component';
 import { PostComposerComponent } from './pages/report/post-composer/post-composer.component';
+import { AreaIndicatorsComponent } from './pages/report/area-indicators/area-indicators.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -23,6 +24,7 @@ registerLocaleData(localePt);
     FooterComponent,
     ReportComponent,
     PostComposerComponent,
+    AreaIndicatorsComponent,
     AdminComponent,
     NotFoundComponent
   ],

--- a/frontend/src/app/core/indicators.service.ts
+++ b/frontend/src/app/core/indicators.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+export interface IndicatorDefinition {
+  id: number;
+  code: string;
+  name: string;
+  unit: string;
+  target?: number;
+  description?: string;
+}
+
+export interface IndicatorData extends IndicatorDefinition {
+  value: number | null;
+  source: string;
+  status: 'good' | 'warning' | 'critical' | 'unknown';
+}
+
+/**
+ * Provides indicator definitions and values per area.
+ * Currently returns mock data but is ready for future API/PI integration.
+ */
+@Injectable({ providedIn: 'root' })
+export class IndicatorsService {
+  private readonly mockDefinitions: Record<string, IndicatorDefinition[]> = {
+    'Calcinação': [
+      { id: 1, code: 'calciner_temp', name: 'Temperatura de saída do calciner', unit: '°C', target: 950 },
+      { id: 2, code: 'gas_consumption', name: 'Consumo específico de gás', unit: 'Nm³/t', target: 100 },
+      { id: 3, code: 'forno_disp', name: 'Disponibilidade do forno', unit: '%', target: 90 }
+    ],
+    'Precipitação': [
+      { id: 4, code: 'solidos_semente', name: 'Sólidos na semente', unit: '%', target: 10 },
+      { id: 5, code: 'eficiencia_crescimento', name: 'Eficiência de crescimento', unit: 'kg/m³·d', target: 50 }
+    ],
+    'Vapor e Utilidades': [
+      { id: 6, code: 'pressao_header', name: 'Pressão header', unit: 'bar', target: 40 },
+      { id: 7, code: 'consumo_vapor', name: 'Consumo de vapor', unit: 't/h', target: 100 }
+    ],
+    'Águas e Efluentes': [
+      { id: 8, code: 'ph_efluente', name: 'pH efluente', unit: '', target: 7 },
+      { id: 9, code: 'dbo', name: 'DBO', unit: 'mg/L', target: 50 },
+      { id: 10, code: 'vazao', name: 'Vazão', unit: 'm³/h', target: 120 }
+    ],
+    'Filtro Prensa': [
+      { id: 11, code: 'umidade_bolo', name: 'Umidade do bolo', unit: '%', target: 30 },
+      { id: 12, code: 'ciclos_h', name: 'Ciclos por hora', unit: 'ciclos/h', target: 5 }
+    ]
+  };
+
+  constructor() {}
+
+  /**
+   * Returns indicators for the given area/date/shift. Mock data ignores date/shift
+   * but keeps the parameters for future compatibility.
+   */
+  getIndicators(area: string, _date: string, _shift: number): Observable<IndicatorData[]> {
+    const defs = this.mockDefinitions[area] || [];
+    const data = defs.map((d) => {
+      const value = this.generateValue(d);
+      return { ...d, value, source: 'mock', status: this.evaluateStatus(value, d.target) };
+    });
+    return of(data);
+  }
+
+  private generateValue(def: IndicatorDefinition): number {
+    const base = def.target ?? 0;
+    const variation = base * (0.8 + Math.random() * 0.4);
+    return Number(variation.toFixed(2));
+  }
+
+  private evaluateStatus(value: number | null, target?: number): 'good' | 'warning' | 'critical' | 'unknown' {
+    if (value == null || target == null) return 'unknown';
+    if (value <= target) return 'good';
+    if (value <= target * 1.1) return 'warning';
+    return 'critical';
+  }
+}

--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.css
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.css
@@ -1,0 +1,1 @@
+/* placeholder for future styling */

--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
@@ -1,0 +1,27 @@
+<section class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
+  <h3 class="text-lg font-semibold mb-2">Indicadores por Área</h3>
+
+  <ng-container *ngIf="(indicators$ | async) as list">
+    <ng-container *ngIf="list.length; else empty">
+      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div *ngFor="let ind of list" class="p-3 border rounded bg-white dark:bg-gray-900">
+          <div class="font-medium">{{ ind.name }}</div>
+          <div class="text-2xl">
+            {{ ind.value !== null ? (ind.value | number:'1.2-2':'pt-BR') : '—' }}
+            <span class="text-base">{{ ind.unit }}</span>
+          </div>
+          <div *ngIf="ind.target !== undefined" class="text-sm text-gray-500">Meta: {{ ind.target | number:'1.2-2':'pt-BR' }} {{ ind.unit }}</div>
+          <div class="text-sm mt-1" [ngClass]="{'text-green-600': ind.status==='good','text-yellow-600': ind.status==='warning','text-red-600': ind.status==='critical'}">
+            {{ statusLabel(ind) }}
+          </div>
+        </div>
+      </div>
+      <p *ngIf="source" class="text-xs text-gray-500 mt-2">Fonte: {{ source === 'mock' ? 'Dados simulados' : source }}</p>
+    </ng-container>
+  </ng-container>
+
+  <ng-template #empty>
+    <p class="text-gray-500" *ngIf="!loading">Sem indicadores configurados para esta área.</p>
+    <p class="text-gray-500" *ngIf="loading">Carregando...</p>
+  </ng-template>
+</section>

--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnDestroy } from '@angular/core';
+import { AppStateService, ReportContext } from '../../../core/app-state.service';
+import { IndicatorsService, IndicatorData } from '../../../core/indicators.service';
+import { Observable, Subject } from 'rxjs';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-area-indicators',
+  templateUrl: './area-indicators.component.html',
+  styleUrls: ['./area-indicators.component.css']
+})
+export class AreaIndicatorsComponent implements OnDestroy {
+  indicators$: Observable<IndicatorData[]>;
+  loading = true;
+  error = false;
+  source = '';
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private appState: AppStateService, private indicators: IndicatorsService) {
+    this.indicators$ = this.appState.context$.pipe(
+      tap(() => { this.loading = true; this.error = false; }),
+      switchMap((ctx: ReportContext) => this.indicators.getIndicators(ctx.area, ctx.date, ctx.shift)),
+      tap((list) => {
+        this.loading = false;
+        this.source = list[0]?.source || '';
+      }),
+      takeUntil(this.destroy$)
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  retry(): void {
+    this.appState.setArea(this.appState.context.area);
+  }
+
+  statusLabel(ind: IndicatorData): string {
+    switch (ind.status) {
+      case 'good':
+        return 'Dentro da meta';
+      case 'warning':
+        return 'Atenção';
+      case 'critical':
+        return 'Crítico';
+      default:
+        return '';
+    }
+  }
+}

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -6,10 +6,7 @@
     <app-post-composer></app-post-composer>
   </section>
 
-  <section id="area-indicators" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
-    <h3 class="text-lg font-semibold mb-2">Indicadores por Área</h3>
-    <p class="text-gray-500 dark:text-gray-400">Placeholder</p>
-  </section>
+  <app-area-indicators id="area-indicators"></app-area-indicators>
 
   <section id="urgencies" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
     <h3 class="text-lg font-semibold mb-2">Urgências</h3>


### PR DESCRIPTION
## Summary
- add indicator service with mock definitions and values
- display area indicators block reacting to header context
- wire component into module and report page

## Testing
- `npm test` *(fails: Cannot find module 'dompurify'; Chrome browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae8e384c83259b063490ab94c6e4