### PR TITLE
feat: add context-aware post lists

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -144,7 +144,11 @@ app.post('/api/posts', upload.array('attachments'), async (req, res) => {
 
     const fullPost = await prisma.post.findUnique({
       where: { id: post.id },
-      include: { attachments: true },
+      include: {
+        attachments: true,
+        author: true,
+        _count: { replies: true },
+      },
     });
     res.status(201).json(fullPost);
   } catch (error) {
@@ -164,7 +168,11 @@ app.get('/api/posts', async (req, res) => {
     orderBy: { createdAt: 'desc' },
     skip: (Number(page) - 1) * Number(pageSize),
     take: Number(pageSize),
-    include: { attachments: true },
+    include: {
+      attachments: true,
+      author: true,
+      _count: { replies: true },
+    },
   });
   res.json(posts);
 });
@@ -173,7 +181,12 @@ app.get('/api/posts/:id', async (req, res) => {
   const id = Number(req.params.id);
   const post = await prisma.post.findUnique({
     where: { id },
-    include: { attachments: true, replies: { include: { attachments: true } } },
+    include: {
+      attachments: true,
+      author: true,
+      replies: { include: { attachments: true, author: true } },
+      _count: { replies: true },
+    },
   });
   if (!post) return res.status(404).json({ error: 'Post not found' });
   res.json(post);

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { FooterComponent } from './layout/footer/footer.component';
 import { ReportComponent } from './pages/report/report.component';
 import { PostComposerComponent } from './pages/report/post-composer/post-composer.component';
 import { AreaIndicatorsComponent } from './pages/report/area-indicators/area-indicators.component';
+import { PostListComponent } from './pages/report/post-list/post-list.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -25,6 +26,7 @@ registerLocaleData(localePt);
     ReportComponent,
     PostComposerComponent,
     AreaIndicatorsComponent,
+    PostListComponent,
     AdminComponent,
     NotFoundComponent
   ],

--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -1,9 +1,31 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 export type PostType = 'ANNOTATION' | 'URGENCY' | 'PENDENCY';
+
+export interface Attachment {
+  id: number;
+  filename: string;
+  mimeType: string;
+  size: number;
+  url: string;
+}
+
+export interface Post {
+  id: number;
+  areaId: number;
+  date: string;
+  shift: number;
+  type: PostType;
+  content: string;
+  author: { id: number; name: string };
+  createdAt: string;
+  updatedAt: string;
+  attachments: Attachment[];
+  _count: { replies: number };
+}
 
 export interface PostCreate {
   areaId: number;
@@ -36,5 +58,31 @@ export class PostsService {
     return this.http.post<any>('/api/posts', form).pipe(
       tap((post) => this.createdSource.next(post))
     );
+  }
+
+  /** Retrieves posts for the given context and type. */
+  list(areaId: number, date: string, shift: number, type: PostType, page = 1, pageSize = 10): Observable<Post[]> {
+    const params = new HttpParams()
+      .set('areaId', String(areaId))
+      .set('date', date)
+      .set('shift', String(shift))
+      .set('type', type)
+      .set('page', String(page))
+      .set('pageSize', String(pageSize));
+    return this.http.get<Post[]>('/api/posts', { params });
+  }
+
+  /** Returns post counts grouped by type for the context. */
+  summary(areaId: number, date: string, shift: number): Observable<any[]> {
+    const params = new HttpParams()
+      .set('areaId', String(areaId))
+      .set('date', date)
+      .set('shift', String(shift));
+    return this.http.get<any[]>('/api/summary', { params });
+  }
+
+  /** Retrieves a single post by id. */
+  get(id: number): Observable<Post> {
+    return this.http.get<Post>(`/api/posts/${id}`);
   }
 }

--- a/frontend/src/app/pages/report/post-list/post-list.component.css
+++ b/frontend/src/app/pages/report/post-list/post-list.component.css
@@ -1,0 +1,1 @@
+/* Minimal styling handled by Tailwind utility classes */

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -1,0 +1,34 @@
+<section class="p-4 border border-gray-200 dark:border-gray-700 rounded mb-8">
+  <h3 class="text-lg font-semibold mb-4">{{ title }} ({{ count }})</h3>
+  <div *ngIf="loading" class="text-gray-500 dark:text-gray-400">Carregando...</div>
+  <div *ngIf="error" class="text-red-600">
+    Erro ao carregar. <button (click)="retry()" class="underline">Tentar novamente</button>
+  </div>
+  <div *ngIf="!loading && !error && posts.length === 0" class="text-gray-500 dark:text-gray-400">
+    Sem {{ title.toLowerCase() }} para este turno.
+  </div>
+  <article *ngFor="let post of posts; trackBy: trackById" [attr.id]="'post-' + post.id" class="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded" [class.bg-yellow-50]="post.id === highlightId">
+    <div class="flex justify-between items-start">
+      <span class="text-xs font-semibold px-2 py-1 rounded" [ngClass]="tagClass()">{{ typeLabel() }}</span>
+      <span class="text-xs text-gray-500">{{ post.author.name }} — {{ post.createdAt | date:'dd/MM/yyyy HH:mm' }}</span>
+    </div>
+    <div class="mt-2 prose prose-sm max-w-none" [innerHTML]="post.content"></div>
+    <div *ngIf="post.attachments.length" class="mt-2 flex flex-wrap gap-2">
+      <ng-container *ngFor="let att of post.attachments">
+        <img *ngIf="att.mimeType.startsWith('image/')" [src]="att.url" [alt]="att.filename" class="w-24 h-24 object-cover border" />
+        <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-blue-600 text-sm underline">
+          📄 {{ att.filename }}
+        </a>
+      </ng-container>
+    </div>
+    <div class="mt-2 flex items-center gap-4 text-sm text-gray-600">
+      <button class="text-blue-600 hover:underline" (click)="reply(post)">Responder</button>
+      <button class="text-blue-600 hover:underline" (click)="copyLink(post)">Copiar link</button>
+      <span>{{ post._count.replies }} respostas</span>
+      <span>Atualizado {{ post.updatedAt | date:'dd/MM HH:mm' }}</span>
+    </div>
+  </article>
+  <div *ngIf="!loading && posts.length < count" class="text-center mt-4">
+    <button (click)="loadMore()" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Carregar mais</button>
+  </div>
+</section>

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -1,0 +1,148 @@
+import { Component, Input, OnDestroy, OnChanges, SimpleChanges } from '@angular/core';
+import { AppStateService, ReportContext } from '../../../core/app-state.service';
+import { PostsService, PostType, Post } from '../../../core/posts.service';
+import { AreasService } from '../../../core/areas.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-post-list',
+  templateUrl: './post-list.component.html',
+  styleUrls: ['./post-list.component.css']
+})
+export class PostListComponent implements OnDestroy, OnChanges {
+  @Input() type!: PostType;
+  @Input() title!: string;
+  @Input() highlightId?: number;
+
+  posts: Post[] = [];
+  count = 0;
+  loading = true;
+  error = false;
+  private page = 1;
+  private ctx!: ReportContext;
+  private areaMap = new Map<string, number>();
+  private destroy$ = new Subject<void>();
+
+  constructor(private appState: AppStateService, private postsService: PostsService, private areas: AreasService) {
+    this.areas.getAreasWithIds().pipe(takeUntil(this.destroy$)).subscribe((areas) => {
+      for (const a of areas) this.areaMap.set(a.name, a.id);
+      if (this.ctx) this.reset();
+    });
+
+    this.appState.context$.pipe(takeUntil(this.destroy$)).subscribe((c) => {
+      this.ctx = c;
+      this.reset();
+    });
+
+    this.postsService.created$.pipe(takeUntil(this.destroy$)).subscribe((post: Post) => {
+      const areaName = [...this.areaMap.entries()].find(([, id]) => id === post.areaId)?.[0];
+      const dateIso = post.date.substring(0,10);
+      if (post.type === this.type && areaName === this.ctx.area && dateIso === this.ctx.date && post.shift === this.ctx.shift) {
+        this.reset();
+      }
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['highlightId']) {
+      this.scrollToHighlight();
+    }
+  }
+
+  private reset(): void {
+    this.page = 1;
+    this.posts = [];
+    this.loadCount();
+    this.loadPage();
+  }
+
+  private loadCount(): void {
+    const areaId = this.areaMap.get(this.ctx.area) || 0;
+    this.postsService.summary(areaId, this.ctx.date, this.ctx.shift).subscribe({
+      next: (list) => {
+        const entry = list.find((e) => e.type === this.type);
+        this.count = entry? entry._count._all : 0;
+      },
+      error: () => {}
+    });
+  }
+
+  private loadPage(): void {
+    const areaId = this.areaMap.get(this.ctx.area) || 0;
+    this.loading = true;
+    this.error = false;
+    this.postsService.list(areaId, this.ctx.date, this.ctx.shift, this.type, this.page).subscribe({
+      next: (posts) => {
+        this.posts = this.posts.concat(posts);
+        this.loading = false;
+        this.scrollToHighlight();
+      },
+      error: () => {
+        this.loading = false;
+        this.error = true;
+      }
+    });
+  }
+
+  loadMore(): void {
+    this.page++;
+    this.loadPage();
+  }
+
+  retry(): void {
+    this.reset();
+  }
+
+  copyLink(post: Post): void {
+    const url = `${window.location.pathname}?area=${encodeURIComponent(this.ctx.area)}&date=${this.ctx.date}&shift=${this.ctx.shift}#post-${post.id}`;
+    navigator.clipboard.writeText(url);
+  }
+
+  reply(post: Post): void {
+    window.location.hash = `post-${post.id}-reply`;
+  }
+
+  trackById(_: number, item: Post): number {
+    return item.id;
+  }
+
+  typeLabel(): string {
+    switch (this.type) {
+      case 'URGENCY':
+        return 'Urgência';
+      case 'PENDENCY':
+        return 'Pendência';
+      default:
+        return 'Anotação';
+    }
+  }
+
+  tagClass(): string {
+    switch (this.type) {
+      case 'URGENCY':
+        return 'bg-red-100 text-red-800';
+      case 'PENDENCY':
+        return 'bg-yellow-100 text-yellow-800';
+      default:
+        return 'bg-blue-100 text-blue-800';
+    }
+  }
+
+  private scrollToHighlight(): void {
+    if (!this.highlightId) return;
+    setTimeout(() => {
+      const el = document.getElementById(`post-${this.highlightId}`);
+      if (el) {
+        el.scrollIntoView();
+        el.classList.add('ring', 'ring-yellow-400');
+        setTimeout(() => el.classList.remove('ring', 'ring-yellow-400'), 2000);
+      }
+    }, 100);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -7,19 +7,14 @@
   </section>
 
   <app-area-indicators id="area-indicators"></app-area-indicators>
+  <div *ngIf="otherContext" class="p-4 bg-yellow-100 border border-yellow-300 rounded">
+    Post pertencente a outro contexto.
+    <button (click)="changeContext()" class="underline">Ajustar contexto</button>
+  </div>
 
-  <section id="urgencies" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
-    <h3 class="text-lg font-semibold mb-2">Urgências</h3>
-    <p class="text-gray-500 dark:text-gray-400">Placeholder</p>
-  </section>
+  <app-post-list id="urgencies" type="URGENCY" title="Urgências" [highlightId]="highlightType === 'URGENCY' ? highlightId : undefined"></app-post-list>
 
-  <section id="pendencies" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
-    <h3 class="text-lg font-semibold mb-2">Pendências</h3>
-    <p class="text-gray-500 dark:text-gray-400">Placeholder</p>
-  </section>
+  <app-post-list id="pendencies" type="PENDENCY" title="Pendências" [highlightId]="highlightType === 'PENDENCY' ? highlightId : undefined"></app-post-list>
 
-  <section id="notes" class="p-4 border border-dashed border-gray-300 dark:border-gray-700 rounded">
-    <h3 class="text-lg font-semibold mb-2">Anotações</h3>
-    <p class="text-gray-500 dark:text-gray-400">Placeholder</p>
-  </section>
+  <app-post-list id="notes" type="ANNOTATION" title="Anotações" [highlightId]="highlightType === 'ANNOTATION' ? highlightId : undefined"></app-post-list>
 </div>

--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { AppStateService, ReportContext } from '../../core/app-state.service';
 import { Observable } from 'rxjs';
+import { PostsService, PostType } from '../../core/posts.service';
+import { AreasService, Area } from '../../core/areas.service';
 
 @Component({
   selector: 'app-report',
@@ -10,5 +12,43 @@ import { Observable } from 'rxjs';
 export class ReportComponent {
   readonly context$: Observable<ReportContext> = this.appState.context$;
 
-  constructor(private appState: AppStateService) {}
+  highlightId?: number;
+  highlightType?: PostType;
+  otherContext?: ReportContext;
+  private areas: Area[] = [];
+
+  constructor(private appState: AppStateService, private posts: PostsService, private areasService: AreasService) {
+    this.areasService.getAreasWithIds().subscribe((areas) => {
+      this.areas = areas;
+      this.checkDeepLink();
+    });
+  }
+
+  private checkDeepLink(): void {
+    const match = window.location.hash.match(/post-(\d+)/);
+    if (!match) return;
+    const id = Number(match[1]);
+    this.posts.get(id).subscribe({
+      next: (post) => {
+        const areaName = this.areas.find((a) => a.id === post.areaId)?.name || '';
+        const dateIso = post.date.substring(0, 10);
+        const ctx = this.appState.context;
+        this.highlightId = id;
+        this.highlightType = post.type;
+        if (ctx.area !== areaName || ctx.date !== dateIso || ctx.shift !== post.shift) {
+          this.otherContext = { area: areaName, date: dateIso, shift: post.shift };
+        }
+      },
+      error: () => {}
+    });
+  }
+
+  changeContext(): void {
+    if (this.otherContext) {
+      this.appState.setArea(this.otherContext.area);
+      this.appState.setDate(this.otherContext.date);
+      this.appState.setShift(this.otherContext.shift);
+      this.otherContext = undefined;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- show report posts grouped as Urgências, Pendências and Anotações
- fetch posts from API with author, attachments and reply counts
- handle deep links and allow context adjustment for mismatched posts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9afce0ef483258ac7eefb7b5bb665