### PR TITLE
feat: add threaded replies for posts

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { ReportComponent } from './pages/report/report.component';
 import { PostComposerComponent } from './pages/report/post-composer/post-composer.component';
 import { AreaIndicatorsComponent } from './pages/report/area-indicators/area-indicators.component';
 import { PostListComponent } from './pages/report/post-list/post-list.component';
+import { ReplyThreadComponent } from './pages/report/reply-thread/reply-thread.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -27,6 +28,7 @@ registerLocaleData(localePt);
     PostComposerComponent,
     AreaIndicatorsComponent,
     PostListComponent,
+    ReplyThreadComponent,
     AdminComponent,
     NotFoundComponent
   ],

--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Attachment } from './posts.service';
+
+export interface Reply {
+  id: number;
+  postId: number;
+  content: string;
+  author: { id: number; name: string };
+  createdAt: string;
+  attachments: Attachment[];
+}
+
+export interface ReplyPage {
+  replies: Reply[];
+  total: number;
+}
+
+export interface ReplyCreate {
+  content: string;
+  attachments: File[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class RepliesService {
+  private createdSource = new Subject<Reply>();
+  readonly created$ = this.createdSource.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  list(postId: number, page = 1, pageSize = 5): Observable<ReplyPage> {
+    const params = new HttpParams()
+      .set('page', String(page))
+      .set('pageSize', String(pageSize));
+    return this.http.get<ReplyPage>(`/api/posts/${postId}/replies`, { params });
+  }
+
+  create(postId: number, payload: ReplyCreate): Observable<Reply> {
+    const form = new FormData();
+    form.append('content', payload.content);
+    for (const file of payload.attachments) {
+      form.append('attachments', file);
+    }
+    return this.http
+      .post<Reply>(`/api/posts/${postId}/replies`, form)
+      .pipe(tap((r) => this.createdSource.next(r)));
+  }
+}

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -22,11 +22,12 @@
       </ng-container>
     </div>
     <div class="mt-2 flex items-center gap-4 text-sm text-gray-600">
-      <button class="text-blue-600 hover:underline" (click)="reply(post)">Responder</button>
+      <button class="text-blue-600 hover:underline" (click)="thread.toggleComposer()">Responder</button>
       <button class="text-blue-600 hover:underline" (click)="copyLink(post)">Copiar link</button>
       <span>{{ post._count.replies }} respostas</span>
       <span>Atualizado {{ post.updatedAt | date:'dd/MM HH:mm' }}</span>
     </div>
+    <app-reply-thread #thread [post]="post"></app-reply-thread>
   </article>
   <div *ngIf="!loading && posts.length < count" class="text-center mt-4">
     <button (click)="loadMore()" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Carregar mais</button>

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -99,10 +99,6 @@ export class PostListComponent implements OnDestroy, OnChanges {
     navigator.clipboard.writeText(url);
   }
 
-  reply(post: Post): void {
-    window.location.hash = `post-${post.id}-reply`;
-  }
-
   trackById(_: number, item: Post): number {
     return item.id;
   }

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.css
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.css
@@ -1,0 +1,1 @@
+/* Additional styling for reply thread */

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -1,0 +1,38 @@
+<div class="mt-2 border-l pl-4"> 
+  <div *ngIf="loading" class="text-gray-500 dark:text-gray-400">Carregando respostas...</div>
+  <div *ngIf="error" class="text-red-600">Falha ao carregar respostas. <button class="underline" (click)="load()">Tentar novamente</button></div>
+  <div *ngIf="!loading && !error && replies.length === 0" class="text-gray-500 dark:text-gray-400">Nenhuma resposta para este post.</div>
+  <ng-container *ngFor="let r of replies">
+    <article class="mb-2">
+      <div class="text-xs text-gray-500">{{ r.author.name }} — {{ r.createdAt | date:'dd/MM/yyyy HH:mm' }}</div>
+      <div class="prose prose-sm max-w-none" [innerHTML]="r.content"></div>
+      <div *ngIf="r.attachments.length" class="mt-1 flex flex-wrap gap-2">
+        <ng-container *ngFor="let att of r.attachments">
+          <img *ngIf="att.mimeType.startsWith('image/')" [src]="att.url" [alt]="att.filename" class="w-16 h-16 object-cover border" />
+          <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-blue-600 text-sm underline">
+            📄 {{ att.filename }}
+          </a>
+        </ng-container>
+      </div>
+    </article>
+  </ng-container>
+  <button *ngIf="replies.length < total && !loading" (click)="loadMore()" class="text-sm text-blue-600 underline">Ver mais respostas</button>
+  <div *ngIf="showForm" class="mt-2">
+    <div #editor contenteditable="true" class="border p-2 rounded min-h-[80px]" (drop)="onDrop($event)" (paste)="onPaste($event)"></div>
+    <input type="file" multiple (change)="onFileInput($event)" class="mt-2" />
+    <div *ngIf="attachments.length" class="mt-2 flex flex-wrap gap-2">
+      <ng-container *ngFor="let att of attachments">
+        <div class="relative">
+          <img *ngIf="att.url" [src]="att.url" class="w-16 h-16 object-cover border" />
+          <span *ngIf="!att.url" class="text-xs">{{ att.file.name }}</span>
+          <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-red-600 bg-white">✕</button>
+        </div>
+      </ng-container>
+    </div>
+    <div class="mt-2 flex items-center gap-2">
+      <button (click)="send()" [disabled]="sending" class="px-3 py-1 bg-blue-600 text-white rounded">Enviar</button>
+      <button (click)="toggleComposer()" class="px-3 py-1">Cancelar</button>
+      <span class="text-sm text-gray-600" *ngIf="message">{{ message }}</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -1,0 +1,154 @@
+import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+import DOMPurify from 'dompurify';
+import { Post } from '../../../core/posts.service';
+import { RepliesService, Reply } from '../../../core/replies.service';
+
+interface AttachmentView {
+  file: File;
+  url?: string;
+  error?: string;
+}
+
+@Component({
+  selector: 'app-reply-thread',
+  templateUrl: './reply-thread.component.html',
+  styleUrls: ['./reply-thread.component.css']
+})
+export class ReplyThreadComponent implements OnInit, OnDestroy {
+  @Input() post!: Post;
+  @ViewChild('editor') editor!: ElementRef<HTMLDivElement>;
+
+  replies: Reply[] = [];
+  loading = false;
+  error = false;
+  page = 1;
+  pageSize = 5;
+  total = 0;
+  showForm = false;
+  sending = false;
+  message = '';
+  attachments: AttachmentView[] = [];
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private repliesService: RepliesService) {}
+
+  ngOnInit(): void {
+    this.load();
+    this.repliesService.created$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((r) => {
+        if (r.postId === this.post.id) {
+          this.replies.push(r);
+          this.post._count.replies++;
+          this.total++;
+        }
+      });
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = false;
+    this.repliesService.list(this.post.id, this.page, this.pageSize).subscribe({
+      next: (res) => {
+        this.replies = this.replies.concat(res.replies);
+        this.total = res.total;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.error = true;
+      }
+    });
+  }
+
+  loadMore(): void {
+    this.page++;
+    this.load();
+  }
+
+  toggleComposer(): void {
+    this.showForm = !this.showForm;
+    if (this.showForm) {
+      setTimeout(() => this.editor?.nativeElement.focus());
+    }
+  }
+
+  onFileInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files) this.addFiles(Array.from(input.files));
+  }
+
+  onDrop(evt: DragEvent): void {
+    evt.preventDefault();
+    if (evt.dataTransfer) this.addFiles(Array.from(evt.dataTransfer.files));
+  }
+
+  onPaste(evt: ClipboardEvent): void {
+    const items = evt.clipboardData?.files;
+    if (items && items.length) this.addFiles(Array.from(items));
+  }
+
+  private addFiles(files: File[]): void {
+    for (const file of files) {
+      const total = this.attachments.reduce((sum, a) => sum + a.file.size, 0);
+      if (file.size > 20 * 1024 * 1024) {
+        this.message = `Arquivo muito grande: ${file.name}`;
+        continue;
+      }
+      if (total + file.size > 50 * 1024 * 1024) {
+        this.message = 'Limite total de anexos excedido';
+        break;
+      }
+      if (!['image/png', 'image/jpeg', 'application/pdf'].includes(file.type)) {
+        this.message = `Tipo de arquivo não suportado: ${file.name}`;
+        continue;
+      }
+      const exists = this.attachments.some((a) => a.file.name === file.name && a.file.size === file.size);
+      if (exists) {
+        this.message = `Arquivo duplicado ignorado: ${file.name}`;
+        continue;
+      }
+      const view: AttachmentView = { file };
+      if (file.type.startsWith('image/')) view.url = URL.createObjectURL(file);
+      this.attachments.push(view);
+    }
+  }
+
+  removeAttachment(att: AttachmentView): void {
+    this.attachments = this.attachments.filter((a) => a !== att);
+  }
+
+  send(): void {
+    const html = this.editor.nativeElement.innerHTML.trim();
+    if (!html && this.attachments.length === 0) {
+      this.message = 'Conteúdo vazio.';
+      return;
+    }
+    const sanitized = DOMPurify.sanitize(html);
+    this.sending = true;
+    this.repliesService
+      .create(this.post.id, { content: sanitized, attachments: this.attachments.map((a) => a.file) })
+      .subscribe({
+        next: (reply) => {
+          this.replies.push(reply);
+          this.post._count.replies++;
+          this.total++;
+          this.editor.nativeElement.innerHTML = '';
+          this.attachments = [];
+          this.showForm = false;
+          this.sending = false;
+        },
+        error: () => {
+          this.message = 'Falha ao enviar.';
+          this.sending = false;
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}


### PR DESCRIPTION
## Summary
- add paginated reply endpoint that includes authors
- implement RepliesService and ReplyThreadComponent to show and create replies with attachments
- integrate reply thread into post cards with toggle and count updates

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test -- --watch=false --browsers=ChromeHeadless` (frontend) *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b2f10eb48325a01e7ccfa80481d2