### PR TITLE
feat: label shift buttons

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -24,17 +24,23 @@
       />
 
       <!-- Shift selector -->
-      <div role="group" aria-label="Turno" class="flex border rounded overflow-hidden">
-        <button
+      <div role="radiogroup" aria-label="Turno" class="flex border rounded overflow-hidden">
+        <label
           *ngFor="let s of [1,2,3]"
-          type="button"
-          (click)="onShiftChange(s)"
+          class="px-2 py-1 cursor-pointer focus-within:ring"
           [class.bg-blue-600]="(context$ | async)?.shift === s"
           [class.text-white]="(context$ | async)?.shift === s"
-          class="px-2 py-1 focus:outline-none focus:ring"
         >
-          {{ s }}
-        </button>
+          <input
+            class="sr-only"
+            type="radio"
+            name="shift"
+            [value]="s"
+            [checked]="(context$ | async)?.shift === s"
+            (change)="onShiftChange(s)"
+          />
+          Turno {{ s }}
+        </label>
       </div>
 
       <!-- Export PDF -->


### PR DESCRIPTION
## Summary
- show "Turno 1/2/3" labels in header and implement radio-style shift selector for better accessibility

## Testing
- `npm test` *(fails: Missing script "test"; repository has no tests)*
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bfa37d808325a0341bd64928eae1