### PR TITLE
Log errors when fetching reports

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -88,6 +88,7 @@ app.get('/api/reports', async (req, res) => {
     const reports = await prisma.report.findMany();
     res.json(reports);
   } catch (error) {
+    console.error('Erro ao buscar relatórios', error);
     res.status(500).json({ error: 'Erro ao buscar relatórios' });
   }
 });


### PR DESCRIPTION
## Summary
- log report retrieval failures in API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b9daea48ac83258abff3d4657b456a