### PR TITLE
Log error details when reply creation fails

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -234,6 +234,7 @@ app.post('/api/posts/:id/replies', upload.array('attachments'), async (req, res)
     });
     res.status(201).json(fullReply);
   } catch (error) {
+    console.error('Failed to create reply', error);
     res.status(400).json({ error: 'Failed to create reply' });
   }
 });


### PR DESCRIPTION
## Summary
- log errors when creating replies so exceptions aren't silently ignored

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9db1754f083258b03e089a0efc7c9