### PR TITLE
Mark PostListComponent services as readonly

### DIFF
--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -24,7 +24,11 @@ export class PostListComponent implements OnDestroy, OnChanges {
   private areaMap = new Map<string, number>();
   private destroy$ = new Subject<void>();
 
-  constructor(private appState: AppStateService, private postsService: PostsService, private areas: AreasService) {
+  constructor(
+    private readonly appState: AppStateService,
+    private readonly postsService: PostsService,
+    private readonly areas: AreasService,
+  ) {
     this.areas.getAreasWithIds().pipe(takeUntil(this.destroy$)).subscribe((areas) => {
       for (const a of areas) this.areaMap.set(a.name, a.id);
       if (this.ctx) this.reset();


### PR DESCRIPTION
## Summary
- make injected services readonly in PostListComponent

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)


------
https://chatgpt.com/codex/tasks/task_e_68b9dce9667c8325b5f7788833362c01