### PR TITLE
refactor: make posts service readonly

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -30,7 +30,7 @@ export class PostComposerComponent implements OnInit {
   constructor(
     private appState: AppStateService,
     private areasService: AreasService,
-    private posts: PostsService
+    private readonly posts: PostsService
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- mark PostsService dependency as readonly in PostComposerComponent

## Testing
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc8500708325addc48d59560c648