### PR TITLE
refactor: remove deprecated execCommand

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -40,12 +40,65 @@ export class PostComposerComponent implements OnInit {
   }
 
   format(cmd: string): void {
-    document.execCommand(cmd, false);
+    const selection = document.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    const editorEl = this.editor.nativeElement;
+    if (!editorEl.contains(range.commonAncestorContainer)) {
+      return;
+    }
+    switch (cmd) {
+      case 'bold':
+      case 'italic': {
+        const tag = cmd === 'bold' ? 'b' : 'i';
+        const wrapper = document.createElement(tag);
+        wrapper.appendChild(range.extractContents());
+        range.insertNode(wrapper);
+        selection.removeAllRanges();
+        selection.selectAllChildren(wrapper);
+        break;
+      }
+      case 'insertUnorderedList':
+      case 'insertOrderedList': {
+        const listTag = cmd === 'insertUnorderedList' ? 'ul' : 'ol';
+        const list = document.createElement(listTag);
+        const li = document.createElement('li');
+        li.appendChild(range.extractContents());
+        list.appendChild(li);
+        range.insertNode(list);
+        selection.removeAllRanges();
+        selection.selectAllChildren(li);
+        break;
+      }
+      default:
+        return;
+    }
+    this.saveDraft();
   }
 
   formatLink(): void {
     const url = prompt('URL');
-    if (url) document.execCommand('createLink', false, url);
+    if (!url) {
+      return;
+    }
+    const selection = document.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    const editorEl = this.editor.nativeElement;
+    if (!editorEl.contains(range.commonAncestorContainer)) {
+      return;
+    }
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.appendChild(range.extractContents());
+    range.insertNode(anchor);
+    selection.removeAllRanges();
+    selection.selectAllChildren(anchor);
+    this.saveDraft();
   }
 
   onFileInput(event: Event): void {


### PR DESCRIPTION
## Summary
- avoid deprecated `document.execCommand` for formatting and links

## Testing
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc97d6c08325919021f858c5df87