### PR TITLE
refactor: replace textbox role with textarea

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.css
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.css
@@ -1,4 +1,3 @@
-.editor:empty::before {
-  content: attr(data-placeholder);
+.editor::placeholder {
   color: #757575; /* mid-gray */
 }

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -26,16 +26,14 @@
       <button type="button" (click)="format('insertOrderedList')" aria-label="Lista numerada" class="px-2 py-1 hover:bg-light-gray">1.</button>
       <button type="button" (click)="formatLink()" aria-label="Link" class="px-2 py-1 hover:bg-light-gray">🔗</button>
     </div>
-    <div
+    <textarea
       #editor
-      class="editor p-2 min-h-[120px] outline-none"
-      contenteditable="true"
-      role="textbox"
+      class="editor p-2 min-h-[120px] outline-none w-full"
       aria-label="Conteúdo"
-      data-placeholder="Escreva uma atualização do turno..."
+      placeholder="Escreva uma atualização do turno..."
       (input)="saveDraft()"
       (paste)="onPaste($event)"
-    ></div>
+    ></textarea>
   </div>
 
   <div *ngIf="attachments.length" class="space-y-2">


### PR DESCRIPTION
## Summary
- replace contenteditable div with native `<textarea>` for post composer
- adjust styles and placeholder handling
- update formatting logic to operate on textarea value

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc5338108325930578e5eff271b6