### PR TITLE
fix: mark indicators service as readonly

### DIFF
--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
@@ -17,7 +17,7 @@ export class AreaIndicatorsComponent implements OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private appState: AppStateService, private indicators: IndicatorsService) {
+  constructor(private appState: AppStateService, private readonly indicators: IndicatorsService) {
     this.indicators$ = this.appState.context$.pipe(
       tap(() => { this.loading = true; this.error = false; }),
       switchMap((ctx: ReportContext) => this.indicators.getIndicators(ctx.area, ctx.date, ctx.shift)),


### PR DESCRIPTION
## Summary
- mark IndicatorsService as readonly

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc3aa2688325befb7a956a7b6815