### PR TITLE
refactor: mark createdSource readonly

### DIFF
--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -38,7 +38,7 @@ export interface PostCreate {
 
 @Injectable({ providedIn: 'root' })
 export class PostsService {
-  private createdSource = new Subject<any>();
+  private readonly createdSource = new Subject<any>();
   /** Emits newly created posts so that lists can refresh. */
   readonly created$ = this.createdSource.asObservable();
 


### PR DESCRIPTION
## Summary
- mark createdSource as readonly in PostsService

## Testing
- `npm test -- --watch=false` (fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)

------
https://chatgpt.com/codex/tasks/task_e_68b9db87fcb48325be734c6f5be788ec