### PR TITLE
refactor: use optional chaining in areas service

### DIFF
--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -33,7 +33,7 @@ export class AreasService {
   /** Returns areas with id and name, using fallback data when API fails. */
   getAreasWithIds(): Observable<Area[]> {
     return this.http.get<Area[]>('/api/areas').pipe(
-      map((areas) => (areas && areas.length ? areas : this.fallbackAreas)),
+      map((areas) => (areas?.length ? areas : this.fallbackAreas)),
       catchError(() => of(this.fallbackAreas))
     );
   }


### PR DESCRIPTION
## Summary
- simplify fallback selection in AreasService with optional chaining

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db62e8cc8325a02ce307944066ec