### PR TITLE
refactor: mark http client readonly in areas service

### DIFF
--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -28,7 +28,7 @@ export class AreasService {
     { id: 11, name: 'Meio Ambiente' }
   ];
 
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   /** Returns areas with id and name, using fallback data when API fails. */
   getAreasWithIds(): Observable<Area[]> {


### PR DESCRIPTION
## Summary
- mark injected HttpClient as readonly in AreasService

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9db5045a483259d3ffeaf325d46e1