### PR TITLE
refactor: mark appState as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -14,7 +14,7 @@ export class HeaderComponent implements OnInit {
   readonly context$ = this.appState.context$;
 
   constructor(
-    private appState: AppStateService,
+    private readonly appState: AppStateService,
     private areasService: AreasService,
     private exportService: ExportService
   ) {}


### PR DESCRIPTION
## Summary
- mark AppState dependency as readonly in header component to follow code-style linting

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbd9b2288325bd75d84cd7d0f81a