### PR TITLE
refactor: mark HttpClient as readonly in replies service

### DIFF
--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -28,7 +28,7 @@ export class RepliesService {
   private createdSource = new Subject<Reply>();
   readonly created$ = this.createdSource.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   list(postId: number, page = 1, pageSize = 5): Observable<ReplyPage> {
     const params = new HttpParams()


### PR DESCRIPTION
## Summary
- mark HttpClient dependency as readonly in replies service for immutability

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm test -- --watch=false --browsers=ChromiumHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbc78a308325a7f8436751e84f87