### PR TITLE
chore: mark replies createdSource as readonly

### DIFF
--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -25,7 +25,7 @@ export interface ReplyCreate {
 
 @Injectable({ providedIn: 'root' })
 export class RepliesService {
-  private createdSource = new Subject<Reply>();
+  private readonly createdSource = new Subject<Reply>();
   readonly created$ = this.createdSource.asObservable();
 
   constructor(private http: HttpClient) {}


### PR DESCRIPTION
## Summary
- mark RepliesService createdSource as readonly

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbafa1f88325b2c4271e4ab9d38f