### PR TITLE
refactor: mark AreasService as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -15,7 +15,7 @@ export class HeaderComponent implements OnInit {
 
   constructor(
     private appState: AppStateService,
-    private areasService: AreasService,
+    private readonly areasService: AreasService,
     private exportService: ExportService
   ) {}
 


### PR DESCRIPTION
## Summary
- mark AreasService in HeaderComponent as `readonly` since it's only assigned in the constructor

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbe94f7c8325af0c1408c9730ab1