### PR TITLE
refactor(frontend): mark AppState service as readonly

### DIFF
--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
@@ -17,7 +17,7 @@ export class AreaIndicatorsComponent implements OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private appState: AppStateService, private indicators: IndicatorsService) {
+  constructor(private readonly appState: AppStateService, private indicators: IndicatorsService) {
     this.indicators$ = this.appState.context$.pipe(
       tap(() => { this.loading = true; this.error = false; }),
       switchMap((ctx: ReportContext) => this.indicators.getIndicators(ctx.area, ctx.date, ctx.shift)),


### PR DESCRIPTION
## Summary
- mark AppStateService dependency as readonly in AreaIndicators component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc281614832591a79b8bcdc9b4d4