### PR TITLE
Mark HttpClient field readonly in ExportService

### DIFF
--- a/frontend/src/app/core/export.service.ts
+++ b/frontend/src/app/core/export.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class ExportService {
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   /** Requests a PDF export for the given context. */
   downloadPdf(areaId: number, date: string, shift: number): Observable<Blob> {


### PR DESCRIPTION
## Summary
- mark HttpClient dependency as readonly in ExportService

## Testing
- `npm test -- --watch=false --browsers=ChromiumHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db727be8832599733c833f63a5e2