### PR TITLE
feat(frontend): mark HttpClient dependencies readonly

### DIFF
--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -28,7 +28,7 @@ export class AreasService {
     { id: 11, name: 'Meio Ambiente' }
   ];
 
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   /** Returns areas with id and name, using fallback data when API fails. */
   getAreasWithIds(): Observable<Area[]> {

--- a/frontend/src/app/core/export.service.ts
+++ b/frontend/src/app/core/export.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class ExportService {
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   /** Requests a PDF export for the given context. */
   downloadPdf(areaId: number, date: string, shift: number): Observable<Blob> {

--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -38,11 +38,11 @@ export interface PostCreate {
 
 @Injectable({ providedIn: 'root' })
 export class PostsService {
-  private createdSource = new Subject<any>();
+  private readonly createdSource = new Subject<any>();
   /** Emits newly created posts so that lists can refresh. */
   readonly created$ = this.createdSource.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   /** Sends a new post to the backend API. */
   create(payload: PostCreate): Observable<any> {

--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -25,10 +25,10 @@ export interface ReplyCreate {
 
 @Injectable({ providedIn: 'root' })
 export class RepliesService {
-  private createdSource = new Subject<Reply>();
+  private readonly createdSource = new Subject<Reply>();
   readonly created$ = this.createdSource.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private readonly http: HttpClient) {}
 
   list(postId: number, page = 1, pageSize = 5): Observable<ReplyPage> {
     const params = new HttpParams()


### PR DESCRIPTION
## Summary
- ensure HttpClient services use readonly injection to avoid unintended reassignment

## Testing
- `cd frontend && npm run build`
- `cd frontend && npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db9fe7988325a7856d16f8867953