### PR TITLE
refactor: mark injected services as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -14,9 +14,9 @@ export class HeaderComponent implements OnInit {
   readonly context$ = this.appState.context$;
 
   constructor(
-    private appState: AppStateService,
-    private areasService: AreasService,
-    private exportService: ExportService
+    private readonly appState: AppStateService,
+    private readonly areasService: AreasService,
+    private readonly exportService: ExportService
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- mark constructor-injected services as readonly in header component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbffe014832581c4a8223028567e