### PR TITLE
refactor: mark appState as readonly

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -28,7 +28,7 @@ export class PostComposerComponent implements OnInit {
   private readonly draftKey = 'post-draft';
 
   constructor(
-    private appState: AppStateService,
+    private readonly appState: AppStateService,
     private areasService: AreasService,
     private posts: PostsService
   ) {}


### PR DESCRIPTION
## Summary
- mark PostComposerComponent's appState dependency as readonly

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9dc65ba708325bb838cc7b641ae5c