### PR TITLE
refactor: mark AppState service as readonly

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -7,5 +7,5 @@ import { AppStateService } from './core/app-state.service';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  constructor(private appState: AppStateService) {}
+  constructor(private readonly appState: AppStateService) {}
 }


### PR DESCRIPTION
## Summary
- mark AppComponent's AppState dependency as readonly

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db2b3098832588b1520b5d3ef3bd