### PR TITLE
Remove placeholder text from report header

### DIFF
--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -1,5 +1,5 @@
 <div class="max-w-7xl mx-auto px-4 py-8 space-y-8">
-  <h2 class="text-2xl font-semibold">Relatório de Turno — estrutura base pronta</h2>
+  <h2 class="text-2xl font-semibold">Relatório de Turno</h2>
   <p *ngIf="context$ | async as ctx" class="text-aluminium">{{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}</p>
 
   <section id="composer">


### PR DESCRIPTION
## Summary
- remove placeholder text from report heading

## Testing
- `cd frontend && npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e74f266c8325a33b2b192bb3f01b