### PR TITLE
Estiliza seleção de tipo de post no compositor

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -3,18 +3,55 @@
   (drop)="onDrop($event)"
   (dragover)="$event.preventDefault()"
 >
-  <div class="flex gap-4">
-    <label class="flex items-center gap-1">
-      <input type="radio" name="type" [(ngModel)]="type" value="ANNOTATION" (ngModelChange)="saveDraft()" />
-      <span>Anotação</span>
+  <div
+    role="radiogroup"
+    aria-label="Tipo"
+    class="flex border border-aluminium rounded overflow-hidden"
+  >
+    <label
+      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      [class.bg-hydro-blue]="type === 'ANNOTATION'"
+      [class.text-white]="type === 'ANNOTATION'"
+    >
+      <input
+        class="sr-only"
+        type="radio"
+        name="type"
+        [(ngModel)]="type"
+        value="ANNOTATION"
+        (ngModelChange)="saveDraft()"
+      />
+      Anotação
     </label>
-    <label class="flex items-center gap-1">
-      <input type="radio" name="type" [(ngModel)]="type" value="URGENCY" (ngModelChange)="saveDraft()" />
-      <span>Urgência</span>
+    <label
+      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      [class.bg-hydro-blue]="type === 'URGENCY'"
+      [class.text-white]="type === 'URGENCY'"
+    >
+      <input
+        class="sr-only"
+        type="radio"
+        name="type"
+        [(ngModel)]="type"
+        value="URGENCY"
+        (ngModelChange)="saveDraft()"
+      />
+      Urgência
     </label>
-    <label class="flex items-center gap-1">
-      <input type="radio" name="type" [(ngModel)]="type" value="PENDENCY" (ngModelChange)="saveDraft()" />
-      <span>Pendência</span>
+    <label
+      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      [class.bg-hydro-blue]="type === 'PENDENCY'"
+      [class.text-white]="type === 'PENDENCY'"
+    >
+      <input
+        class="sr-only"
+        type="radio"
+        name="type"
+        [(ngModel)]="type"
+        value="PENDENCY"
+        (ngModelChange)="saveDraft()"
+      />
+      Pendência
     </label>
   </div>
 


### PR DESCRIPTION
## Summary
- Aplica estilo segmentado ao seletor de tipo (Anotação, Urgência, Pendência) para lembrar o seletor de turno do header

## Testing
- `npm test` *(falha: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e7c05bb88325a9948fe05fd1a976