### PR TITLE
feat: apply Hydro branding to shift report screen

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -1,13 +1,23 @@
-<header class="sticky top-0 z-10 bg-white border-b border-light-gray shadow-sm" role="banner">
-  <div class="max-w-7xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4">
-    <img src="assets/brand/hydro/logos/primary/hydro-logo-vertical-blue.png" alt="Hydro" class="h-12" />
-    <h1 class="text-xl font-display text-black">Relatório de Turno</h1>
+<header class="sticky top-0 z-10 bg-white border-b border-light-gray" role="banner">
+  <div class="max-w-[70rem] mx-auto px-4 sm:px-6 lg:px-8 py-3 flex flex-wrap items-center gap-4">
+    <!-- Logos -->
+    <img
+      src="assets/brand/hydro/logos/primary/hydro-logo-vertical-blue.png"
+      alt="Hydro"
+      class="h-10 w-auto hidden sm:block"
+    />
+    <img
+      src="assets/brand/hydro/logos/secondary/hydro-logo-horizontal-blue.png"
+      alt="Hydro"
+      class="h-8 w-auto sm:hidden"
+    />
+
     <div class="flex flex-wrap items-center gap-2 ml-auto text-sm font-arial">
       <!-- Area selector -->
       <label for="area" class="sr-only">Área</label>
       <select
         id="area"
-        class="border border-aluminium rounded px-2 py-1 bg-white"
+        class="px-2 py-1 bg-white border border-aluminium rounded focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
         [ngModel]="(context$ | async)?.area"
         (ngModelChange)="onAreaChange($event)"
       >
@@ -19,16 +29,20 @@
       <input
         id="date"
         type="date"
-        class="border border-aluminium rounded px-2 py-1 bg-white"
+        class="px-2 py-1 bg-white border border-aluminium rounded focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
         [ngModel]="(context$ | async)?.date"
         (ngModelChange)="onDateChange($event)"
       />
 
       <!-- Shift selector -->
-      <div role="radiogroup" aria-label="Turno" class="flex border border-aluminium rounded overflow-hidden">
+      <div
+        role="radiogroup"
+        aria-label="Turno"
+        class="flex border border-aluminium rounded overflow-hidden divide-x divide-aluminium"
+      >
         <label
           *ngFor="let s of [1,2,3]"
-          class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue"
           [class.bg-hydro-blue]="(context$ | async)?.shift === s"
           [class.text-white]="(context$ | async)?.shift === s"
         >

--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
@@ -1,10 +1,10 @@
-<section class="p-4 border border-dashed border-aluminium rounded">
-  <h3 class="text-lg font-semibold mb-2">Indicadores por Área</h3>
+<section class="mt-8 p-6 bg-white border border-light-gray rounded space-y-4">
+  <h2 class="text-xl font-display">Indicadores por Área</h2>
 
   <ng-container *ngIf="(indicators$ | async) as list">
     <ng-container *ngIf="list.length; else empty">
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <div *ngFor="let ind of list" class="p-3 border border-light-gray rounded bg-white">
+        <div *ngFor="let ind of list" class="p-3 border border-light-gray rounded">
           <div class="font-medium">{{ ind.name }}</div>
           <div class="text-2xl">
             {{ ind.value !== null ? (ind.value | number:'1.2-2':'pt-BR') : '—' }}
@@ -16,7 +16,7 @@
           </div>
         </div>
       </div>
-      <p *ngIf="source" class="text-xs text-mid-gray mt-2">Fonte: {{ source === 'mock' ? 'Dados simulados' : source }}</p>
+      <p *ngIf="source" class="text-xs text-mid-gray">Fonte: {{ source === 'mock' ? 'Dados simulados' : source }}</p>
     </ng-container>
   </ng-container>
 

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -1,15 +1,15 @@
 <div
-  class="p-4 border border-aluminium rounded space-y-4"
+  class="p-6 bg-white border border-light-gray rounded space-y-4"
   (drop)="onDrop($event)"
   (dragover)="$event.preventDefault()"
 >
   <div
     role="radiogroup"
     aria-label="Tipo"
-    class="flex border border-aluminium rounded overflow-hidden"
+    class="flex border border-aluminium rounded overflow-hidden divide-x divide-aluminium text-sm"
   >
     <label
-      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'ANNOTATION'"
       [class.text-white]="type === 'ANNOTATION'"
     >
@@ -24,7 +24,7 @@
       Anotação
     </label>
     <label
-      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'URGENCY'"
       [class.text-white]="type === 'URGENCY'"
     >
@@ -39,7 +39,7 @@
       Urgência
     </label>
     <label
-      class="px-2 py-1 cursor-pointer focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'PENDENCY'"
       [class.text-white]="type === 'PENDENCY'"
     >
@@ -55,7 +55,7 @@
     </label>
   </div>
 
-  <div class="border rounded">
+  <div class="border border-light-gray rounded">
     <div class="flex gap-1 border-b p-1">
       <button type="button" (click)="format('bold')" aria-label="Negrito" class="px-2 py-1 hover:bg-light-gray">B</button>
       <button type="button" (click)="format('italic')" aria-label="Itálico" class="px-2 py-1 hover:bg-light-gray"><em>I</em></button>
@@ -69,7 +69,7 @@
       contenteditable="true"
       role="textbox"
       aria-label="Conteúdo"
-      data-placeholder="Escreva uma atualização do turno..."
+      data-placeholder="Escreva uma atualização do turno… Ex.: status de produção, ocorrências, apontamentos"
       (input)="saveDraft()"
       (paste)="onPaste($event)"
     ></div>
@@ -79,12 +79,12 @@
     <div *ngFor="let att of attachments" class="flex items-center gap-2">
       <img *ngIf="att.url" [src]="att.url" alt="Pré-visualização" class="w-16 h-16 object-cover rounded" />
       <span class="text-sm">{{ att.file.name }} ({{ att.file.size / 1024 | number:'1.0-0' }} KB)</span>
-      <button type="button" (click)="removeAttachment(att)" class="text-bauxite text-sm">Remover</button>
+      <button type="button" (click)="removeAttachment(att)" class="text-hydro-blue text-sm underline">Remover</button>
     </div>
   </div>
 
   <div class="flex items-center gap-4">
-    <label class="cursor-pointer text-hydro-blue flex items-center gap-1">
+    <label class="cursor-pointer text-hydro-blue flex items-center gap-1 hover:underline">
       <input type="file" multiple class="hidden" (change)="onFileInput($event)" />
       <span>Anexar arquivos</span>
     </label>
@@ -96,6 +96,12 @@
     >
       {{ sending ? 'Publicando…' : 'Publicar' }}
     </button>
-    <span *ngIf="message" class="text-sm" [class.text-bauxite]="message.startsWith('Falha')" [class.text-green]="message.startsWith('Publicação')" >{{ message }}</span>
+    <span
+      *ngIf="message"
+      class="text-sm"
+      [class.text-bauxite]="message.startsWith('Falha')"
+      [class.text-green]="message.startsWith('Publicação')"
+      >{{ message }}</span
+    >
   </div>
 </div>

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -1,13 +1,19 @@
-<section class="p-4 border border-light-gray rounded mb-8">
-  <h3 class="text-lg font-semibold mb-4">{{ title }} ({{ count }})</h3>
-  <div *ngIf="loading" class="text-mid-gray">Carregando...</div>
+<section class="mt-8 p-6 bg-white border border-light-gray rounded space-y-4">
+  <h2 class="text-xl font-display">{{ title }} ({{ count }})</h2>
+  <div *ngIf="loading" class="text-aluminium">Carregando...</div>
   <div *ngIf="error" class="text-bauxite">
-    Erro ao carregar. <button (click)="retry()" class="underline">Tentar novamente</button>
+    Erro ao carregar.
+    <button (click)="retry()" class="text-hydro-blue underline">Tentar novamente</button>
   </div>
-  <div *ngIf="!loading && !error && posts.length === 0" class="text-mid-gray">
+  <div *ngIf="!loading && !error && posts.length === 0" class="text-aluminium">
     Sem {{ title.toLowerCase() }} para este turno.
   </div>
-  <article *ngFor="let post of posts; trackBy: trackById" [attr.id]="'post-' + post.id" class="mb-4 p-4 border border-light-gray rounded" [class.bg-warm]="post.id === highlightId">
+  <article
+    *ngFor="let post of posts; trackBy: trackById"
+    [attr.id]="'post-' + post.id"
+    class="p-4 border border-light-gray rounded" [class.bg-warm]="post.id === highlightId"
+    [class.mt-4]="post !== posts[0]"
+  >
     <div class="flex justify-between items-start">
       <span class="text-xs font-semibold px-2 py-1 rounded" [ngClass]="tagClass()">{{ typeLabel() }}</span>
       <span class="text-xs text-mid-gray">{{ post.author.name }} — {{ post.createdAt | date:'dd/MM/yyyy HH:mm' }}</span>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -1,6 +1,9 @@
 <div class="mt-2 border-l border-light-gray pl-4">
   <div *ngIf="loading" class="text-mid-gray">Carregando respostas...</div>
-  <div *ngIf="error" class="text-bauxite">Falha ao carregar respostas. <button class="underline" (click)="load()">Tentar novamente</button></div>
+  <div *ngIf="error" class="text-bauxite">
+    Falha ao carregar respostas.
+    <button class="text-hydro-blue underline" (click)="load()">Tentar novamente</button>
+  </div>
   <div *ngIf="!loading && !error && replies.length === 0" class="text-mid-gray">Nenhuma resposta para este post.</div>
   <ng-container *ngFor="let r of replies">
     <article class="mb-2">
@@ -25,7 +28,7 @@
         <div class="relative">
           <img *ngIf="att.url" [src]="att.url" class="w-16 h-16 object-cover border border-light-gray" />
           <span *ngIf="!att.url" class="text-xs">{{ att.file.name }}</span>
-          <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-bauxite bg-white">✕</button>
+          <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-hydro-blue bg-white">✕</button>
         </div>
       </ng-container>
     </div>

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -1,6 +1,18 @@
-<div class="max-w-7xl mx-auto px-4 py-8 space-y-8">
-  <h2 class="text-2xl font-semibold">Relatório de Turno</h2>
-  <p *ngIf="context$ | async as ctx" class="text-aluminium">{{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}</p>
+<div class="max-w-[70rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">
+  <div class="flex items-start justify-between">
+    <div>
+      <h1 class="text-3xl font-display text-black">Relatório de Turno</h1>
+      <p *ngIf="context$ | async as ctx" class="mt-2 text-aluminium font-arial">
+        {{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}
+      </p>
+    </div>
+    <img
+      src="assets/brand/hydro/sail/sail-blue.eps"
+      alt=""
+      aria-hidden="true"
+      class="w-24 h-24 object-contain opacity-20"
+    />
+  </div>
 
   <section id="composer">
     <app-post-composer></app-post-composer>
@@ -9,12 +21,27 @@
   <app-area-indicators id="area-indicators"></app-area-indicators>
   <div *ngIf="otherContext" class="p-4 bg-warm border border-aluminium rounded">
     Post pertencente a outro contexto.
-    <button (click)="changeContext()" class="underline">Ajustar contexto</button>
+    <button (click)="changeContext()" class="text-hydro-blue underline">Ajustar contexto</button>
   </div>
 
-  <app-post-list id="urgencies" type="URGENCY" title="Urgências" [highlightId]="highlightType === 'URGENCY' ? highlightId : undefined"></app-post-list>
+  <app-post-list
+    id="urgencies"
+    type="URGENCY"
+    title="Urgências"
+    [highlightId]="highlightType === 'URGENCY' ? highlightId : undefined"
+  ></app-post-list>
 
-  <app-post-list id="pendencies" type="PENDENCY" title="Pendências" [highlightId]="highlightType === 'PENDENCY' ? highlightId : undefined"></app-post-list>
+  <app-post-list
+    id="pendencies"
+    type="PENDENCY"
+    title="Pendências"
+    [highlightId]="highlightType === 'PENDENCY' ? highlightId : undefined"
+  ></app-post-list>
 
-  <app-post-list id="notes" type="ANNOTATION" title="Anotações" [highlightId]="highlightType === 'ANNOTATION' ? highlightId : undefined"></app-post-list>
+  <app-post-list
+    id="notes"
+    type="ANNOTATION"
+    title="Anotações"
+    [highlightId]="highlightType === 'ANNOTATION' ? highlightId : undefined"
+  ></app-post-list>
 </div>


### PR DESCRIPTION
## Summary
- Align header with Hydro logos and consolidated toolbar
- Add page hero with Ivar Display title and subtle Sail graphic
- Restyle composer and content sections as Hydro-styled cards

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea131bc0832597e3306fdc7a820a