### PR TITLE
fix(api): use environment base URL for HTTP calls

### DIFF
--- a/frontend/src/app/core/areas.service.ts
+++ b/frontend/src/app/core/areas.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 export interface Area {
   id: number;
@@ -32,7 +33,7 @@ export class AreasService {
 
   /** Returns areas with id and name, using fallback data when API fails. */
   getAreasWithIds(): Observable<Area[]> {
-    return this.http.get<Area[]>('/api/areas').pipe(
+    return this.http.get<Area[]>(`${environment.apiUrl}/api/areas`).pipe(
       map((areas) => (areas?.length ? areas : this.fallbackAreas)),
       catchError(() => of(this.fallbackAreas))
     );

--- a/frontend/src/app/core/export.service.ts
+++ b/frontend/src/app/core/export.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ExportService {
@@ -8,6 +9,6 @@ export class ExportService {
 
   /** Requests a PDF export for the given context. */
   downloadPdf(areaId: number, date: string, shift: number): Observable<Blob> {
-    return this.http.post('/api/export', { areaId, date, shift }, { responseType: 'blob' });
+    return this.http.post(`${environment.apiUrl}/api/export`, { areaId, date, shift }, { responseType: 'blob' });
   }
 }

--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 export type PostType = 'ANNOTATION' | 'URGENCY' | 'PENDENCY';
 
@@ -55,7 +56,7 @@ export class PostsService {
     for (const file of payload.attachments) {
       form.append('attachments', file);
     }
-    return this.http.post<any>('/api/posts', form).pipe(
+    return this.http.post<any>(`${environment.apiUrl}/api/posts`, form).pipe(
       tap((post) => this.createdSource.next(post))
     );
   }
@@ -69,7 +70,7 @@ export class PostsService {
       .set('type', type)
       .set('page', String(page))
       .set('pageSize', String(pageSize));
-    return this.http.get<Post[]>('/api/posts', { params });
+    return this.http.get<Post[]>(`${environment.apiUrl}/api/posts`, { params });
   }
 
   /** Returns post counts grouped by type for the context. */
@@ -78,11 +79,11 @@ export class PostsService {
       .set('areaId', String(areaId))
       .set('date', date)
       .set('shift', String(shift));
-    return this.http.get<any[]>('/api/summary', { params });
+    return this.http.get<any[]>(`${environment.apiUrl}/api/summary`, { params });
   }
 
   /** Retrieves a single post by id. */
   get(id: number): Observable<Post> {
-    return this.http.get<Post>(`/api/posts/${id}`);
+    return this.http.get<Post>(`${environment.apiUrl}/api/posts/${id}`);
   }
 }

--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Attachment } from './posts.service';
+import { environment } from '../../environments/environment';
 
 export interface Reply {
   id: number;
@@ -34,7 +35,7 @@ export class RepliesService {
     const params = new HttpParams()
       .set('page', String(page))
       .set('pageSize', String(pageSize));
-    return this.http.get<ReplyPage>(`/api/posts/${postId}/replies`, { params });
+    return this.http.get<ReplyPage>(`${environment.apiUrl}/api/posts/${postId}/replies`, { params });
   }
 
   create(postId: number, payload: ReplyCreate): Observable<Reply> {
@@ -44,7 +45,7 @@ export class RepliesService {
       form.append('attachments', file);
     }
     return this.http
-      .post<Reply>(`/api/posts/${postId}/replies`, form)
+      .post<Reply>(`${environment.apiUrl}/api/posts/${postId}/replies`, form)
       .pipe(tap((r) => this.createdSource.next(r)));
   }
 }


### PR DESCRIPTION
## Summary
- use environment.apiUrl in core services

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9f0195b78832580187d4d9515bd03