### PR TITLE
Improve primary blue hover effect

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -36,7 +36,7 @@
 
       <!-- Shift selector -->
       <div role="radiogroup" aria-label="Tipo" class="flex border border-aluminium rounded overflow-hidden divide-x divide-aluminium text-sm">
-        <label class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue bg-hydro-blue text-white flex-1 text-center">
+        <label class="px-3 py-1 cursor-pointer hover:bg-hydro-dark-blue focus-within:ring-2 focus-within:ring-hydro-light-blue bg-hydro-blue text-white flex-1 text-center">
           <input type="radio" name="type" value="ANNOTATION" class="sr-only">
           Anotação
         </label>

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -92,7 +92,7 @@
       type="button"
       (click)="publish()"
       [disabled]="sending"
-      class="px-4 py-2 rounded bg-hydro-blue hover:bg-hydro-light-blue text-white disabled:opacity-50"
+      class="px-4 py-2 rounded bg-hydro-blue hover:bg-hydro-dark-blue text-white disabled:opacity-50"
     >
       {{ sending ? 'Publicando…' : 'Publicar' }}
     </button>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -33,7 +33,7 @@
       </ng-container>
     </div>
     <div class="mt-2 flex items-center gap-2">
-      <button (click)="send()" [disabled]="sending" class="px-3 py-1 bg-hydro-blue hover:bg-hydro-light-blue text-white rounded">Enviar</button>
+      <button (click)="send()" [disabled]="sending" class="px-3 py-1 bg-hydro-blue hover:bg-hydro-dark-blue text-white rounded">Enviar</button>
       <button (click)="toggleComposer()" class="px-3 py-1">Cancelar</button>
       <span class="text-sm text-aluminium" *ngIf="message">{{ message }}</span>
     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -70,7 +70,7 @@
   }
 
   .btn-primary {
-    @apply bg-hydro-blue text-white hover:bg-hydro-light-blue focus:ring-hydro-light-blue;
+    @apply bg-hydro-blue text-white hover:bg-hydro-dark-blue focus:ring-hydro-light-blue;
   }
 
   .btn-secondary {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
       colors: {
         'hydro-blue': '#444D55',
         'hydro-light-blue': '#768692',
+        'hydro-dark-blue': '#333940',
         'aluminium': '#8C8C8C',
         'white': '#FFFFFF',
         'black': '#000000',


### PR DESCRIPTION
## Summary
- Darken primary blue hover state using new `hydro-dark-blue` Tailwind color
- Apply updated hover styling to header selector and report buttons

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f32474bc832596cc7bc23c2abfd8