### PR TITLE
Handle errors in area and profile routes

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -98,15 +98,25 @@ app.get('/api/reports', async (req, res) => {
 
 // ----- Areas -----
 app.get('/api/areas', async (req, res) => {
-  const areas = await prisma.area.findMany();
-  res.json(areas);
+  try {
+    const areas = await prisma.area.findMany();
+    res.json(areas);
+  } catch (error) {
+    console.error('Erro ao buscar áreas', error);
+    res.status(500).json({ error: 'Erro ao buscar áreas' });
+  }
 });
 
 // ----- Profile -----
 app.get('/api/me', async (req, res) => {
-  const userId = Number(req.header('x-user-id')) || 1;
-  const user = await ensureUser(userId);
-  res.json({ id: user.id, name: user.name, avatar: user.avatar, role: user.role });
+  try {
+    const userId = Number(req.header('x-user-id')) || 1;
+    const user = await ensureUser(userId);
+    res.json({ id: user.id, name: user.name, avatar: user.avatar, role: user.role });
+  } catch (error) {
+    console.error('Erro ao buscar usuário', error);
+    res.status(500).json({ error: 'Erro ao buscar usuário' });
+  }
 });
 
 // ----- Posts -----


### PR DESCRIPTION
## Summary
- prevent backend from crashing when DB tables are missing by wrapping `/api/areas` and `/api/me` handlers in try/catch blocks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4cb86d083259e8e584e846cb78b