### PR TITLE
fix: validate area existence before creating posts

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -153,6 +153,10 @@ app.post('/api/posts', upload.array('attachments'), async (req, res) => {
     if (area === undefined || !d || s === undefined || !t) {
       return res.status(400).json({ error: 'Invalid post parameters' });
     }
+    const areaExists = await prisma.area.findUnique({ where: { id: area } });
+    if (!areaExists) {
+      return res.status(400).json({ error: 'Invalid area' });
+    }
     const sanitized = sanitizeHtml(content || '');
     const post = await prisma.post.create({
       data: {


### PR DESCRIPTION
## Summary
- ensure referenced area exists before creating a post to avoid foreign key violations

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68b9fe5d8d108325ba2237385d21f536