### PR TITLE
Restore shift selector in header

### DIFF
--- a/frontend/src/app/core/app-state.service.ts
+++ b/frontend/src/app/core/app-state.service.ts
@@ -18,10 +18,13 @@ export class AppStateService {
 
   constructor() {
     const params = new URLSearchParams(window.location.search);
+    const today = this.todayIso();
+    const date = params.get('date') || today;
+    const shiftParam = params.get('shift');
     const initial: ReportContext = {
       area: params.get('area') || 'Recebimento de Bauxita',
-      date: params.get('date') || this.todayIso(),
-      shift: this.parseShift(params.get('shift'))
+      date,
+      shift: shiftParam ? this.parseShift(shiftParam) : (date === today ? this.currentShift() : 1)
     };
     this.contextSubject = new BehaviorSubject<ReportContext>(initial);
     this.context$ = this.contextSubject.asObservable();
@@ -61,6 +64,19 @@ export class AppStateService {
 
   private todayIso(): string {
     return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(new Date());
+  }
+
+  private currentShift(): number {
+    const hour = Number(
+      new Intl.DateTimeFormat('en-GB', {
+        timeZone: 'America/Sao_Paulo',
+        hour: '2-digit',
+        hour12: false,
+      }).format(new Date())
+    );
+    if (hour >= 6 && hour < 14) return 1;
+    if (hour >= 14 && hour < 22) return 2;
+    return 3;
   }
 
   private parseShift(value: string | null): number {

--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -35,18 +35,59 @@
       />
 
       <!-- Shift selector -->
-      <div role="radiogroup" aria-label="Tipo" class="flex border border-aluminium rounded overflow-hidden divide-x divide-aluminium text-sm">
-        <label class="px-3 py-1 cursor-pointer hover:bg-hydro-dark-blue focus-within:ring-2 focus-within:ring-hydro-light-blue bg-hydro-blue text-white flex-1 text-center">
-          <input type="radio" name="type" value="ANNOTATION" class="sr-only">
-          Anotação
+      <div
+        role="radiogroup"
+        aria-label="Turno"
+        class="flex border border-aluminium rounded overflow-hidden divide-x divide-aluminium text-sm"
+        *ngIf="context$ | async as ctx"
+      >
+        <label
+          class="px-3 py-1 cursor-pointer flex-1 text-center focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          [ngClass]="ctx.shift === 1 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
+        >
+          <input
+            type="radio"
+            name="shift"
+            class="sr-only"
+            [value]="1"
+            [checked]="ctx.shift === 1"
+            (change)="onShiftChange(1)"
+            [disabled]="!ctx.date"
+            [attr.title]="ctx.date ? undefined : 'Selecione uma data'"
+          />
+          Turno 1
         </label>
-        <label class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue flex-1 text-center">
-          <input type="radio" name="type" value="URGENCY" class="sr-only">
-          Urgência
+        <label
+          class="px-3 py-1 cursor-pointer flex-1 text-center focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          [ngClass]="ctx.shift === 2 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
+        >
+          <input
+            type="radio"
+            name="shift"
+            class="sr-only"
+            [value]="2"
+            [checked]="ctx.shift === 2"
+            (change)="onShiftChange(2)"
+            [disabled]="!ctx.date"
+            [attr.title]="ctx.date ? undefined : 'Selecione uma data'"
+          />
+          Turno 2
         </label>
-        <label class="px-3 py-1 cursor-pointer hover:bg-light-gray focus-within:ring-2 focus-within:ring-hydro-light-blue flex-1 text-center">
-          <input type="radio" name="type" value="PENDENCY" class="sr-only">
-          Pendência
+        <label
+          class="px-3 py-1 cursor-pointer flex-1 text-center focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          [ngClass]="ctx.shift === 3 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
+        >
+          <input
+            type="radio"
+            name="shift"
+            class="sr-only"
+            [value]="3"
+            [checked]="ctx.shift === 3"
+            (change)="onShiftChange(3)"
+            [disabled]="!ctx.date"
+            [attr.title]="ctx.date ? undefined : 'Selecione uma data'"
+          />
+          Turno 3
         </label>
       </div>
 


### PR DESCRIPTION
## Summary
- replace incorrect annotation/urgency/pendency buttons with Turno 1/2/3 radio selector
- infer current shift by default and keep context in URL

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9fdf833c483259411a05683726aa5