### PR TITLE
Seed default areas on startup

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -74,10 +74,33 @@ async function ensureUser(id) {
   });
 }
 
+const defaultAreas = [
+  { name: 'Recebimento de Bauxita' },
+  { name: 'Digestão' },
+  { name: 'Clarificação' },
+  { name: 'Filtro Prensa' },
+  { name: 'Precipitação' },
+  { name: 'Calcinação' },
+  { name: 'Vapor e Utilidades' },
+  { name: 'Águas e Efluentes' },
+  { name: 'Automação e Energia' },
+  { name: 'Porto' },
+  { name: 'Meio Ambiente' },
+];
+
+async function seedAreas() {
+  const count = await prisma.area.count();
+  if (count === 0) {
+    await prisma.area.createMany({ data: defaultAreas });
+    console.log('🌱 Áreas padrão inseridas');
+  }
+}
+
 (async () => {
   try {
     await prisma.$connect();
     console.log('✅ Conexão com banco de dados estabelecida');
+    await seedAreas();
   } catch (error) {
     console.error('❌ Erro ao conectar ao banco de dados', error);
     process.exit(1);


### PR DESCRIPTION
## Summary
- populate area table with predefined entries when empty to fix post creation

## Testing
- `npm test` (fails: Missing script "test")
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: terminated)


------
https://chatgpt.com/codex/tasks/task_e_68b9fff1868c832589ed5a32ca51e45c