### PR TITLE
fix: avoid duplicate replies

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -131,10 +131,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     this.repliesService
       .create(this.post.id, { content: sanitized, attachments: this.attachments.map((a) => a.file) })
       .subscribe({
-        next: (reply) => {
-          this.replies.push(reply);
-          this.post._count.replies++;
-          this.total++;
+        next: () => {
           this.editor.nativeElement.innerHTML = '';
           this.attachments = [];
           this.showForm = false;


### PR DESCRIPTION
## Summary
- avoid double counting and duplication when posting replies

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba02b48460832593a166301187ada3