### PR TITLE
fix: show new replies immediately

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -39,7 +39,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     this.repliesService.created$
       .pipe(takeUntil(this.destroy$))
       .subscribe((r) => {
-        if (r.postId === this.post.id) {
+        if (r.postId === this.post.id && !this.replies.some((rr) => rr.id === r.id)) {
           this.replies.push(r);
           this.post._count.replies++;
           this.total++;
@@ -131,7 +131,10 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     this.repliesService
       .create(this.post.id, { content: sanitized, attachments: this.attachments.map((a) => a.file) })
       .subscribe({
-        next: () => {
+        next: (reply) => {
+          this.replies.push(reply);
+          this.post._count.replies++;
+          this.total++;
           this.editor.nativeElement.innerHTML = '';
           this.attachments = [];
           this.showForm = false;


### PR DESCRIPTION
## Summary
- Ensure reply threads update after creating a reply
- Prevent duplicate replies when handling creation events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0532fad883259a9218b0ba65dc5d