### PR TITLE
fix: display attachments after saving posts

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -208,7 +208,7 @@ app.post('/api/posts', upload.array('attachments'), async (req, res) => {
         filename: sanitizeFilename(f.originalname),
         mimeType: f.mimetype,
         size: f.size,
-        url: `/uploads/${f.filename}`,
+        url: `${req.protocol}://${req.get('host')}/uploads/${f.filename}`,
       }));
       await prisma.attachment.createMany({ data: attachmentsData });
     }
@@ -314,7 +314,7 @@ app.post('/api/posts/:id/replies', upload.array('attachments'), async (req, res)
         filename: sanitizeFilename(f.originalname),
         mimeType: f.mimetype,
         size: f.size,
-        url: `/uploads/${f.filename}`,
+        url: `${req.protocol}://${req.get('host')}/uploads/${f.filename}`,
       }));
       await prisma.attachment.createMany({ data: attData });
     }


### PR DESCRIPTION
## Summary
- use absolute URLs for uploaded attachments

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Missing script)*
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68ba060869688325a93ca62bd053fddb