### PR TITLE
chore: mark AreasService as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -15,7 +15,7 @@ export class HeaderComponent implements OnInit {
 
   constructor(
     private readonly appState: AppStateService,
-    private areasService: AreasService,
+    private readonly areasService: AreasService,
     private exportService: ExportService
   ) {}
 


### PR DESCRIPTION
## Summary
- mark AreasService dependency in HeaderComponent as readonly to follow Angular style and avoid reassignment

## Testing
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09a5232c8325a2c2aba58f525d5a