### PR TITLE
fix: mark header services as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -15,8 +15,8 @@ export class HeaderComponent implements OnInit {
 
   constructor(
     private readonly appState: AppStateService,
-    private areasService: AreasService,
-    private exportService: ExportService
+    private readonly areasService: AreasService,
+    private readonly exportService: ExportService
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- mark AreasService and ExportService as readonly in HeaderComponent

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09b5ebdc8325ac470130e8cbc619