### PR TITLE
style: mark appState as readonly

### DIFF
--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.ts
@@ -17,7 +17,7 @@ export class AreaIndicatorsComponent implements OnDestroy {
 
   private readonly destroy$ = new Subject<void>();
 
-  constructor(private appState: AppStateService, private readonly indicators: IndicatorsService) {
+  constructor(private readonly appState: AppStateService, private readonly indicators: IndicatorsService) {
     this.indicators$ = this.appState.context$.pipe(
       tap(() => { this.loading = true; this.error = false; }),
       switchMap((ctx: ReportContext) => this.indicators.getIndicators(ctx.area, ctx.date, ctx.shift)),


### PR DESCRIPTION
## Summary
- mark AppStateService dependency as readonly in AreaIndicatorsComponent

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09c7390483259414236ce6b09184