### PR TITLE
chore: add alt text to preview images

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -26,7 +26,7 @@
     <div *ngIf="attachments.length" class="mt-2 flex flex-wrap gap-2">
       <ng-container *ngFor="let att of attachments">
         <div class="relative">
-          <img *ngIf="att.url" [src]="att.url" class="w-16 h-16 object-cover border border-light-gray" />
+          <img *ngIf="att.url" [src]="att.url" [alt]="att.file.name" class="w-16 h-16 object-cover border border-light-gray" />
           <span *ngIf="!att.url" class="text-xs">{{ att.file.name }}</span>
           <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-hydro-blue bg-white">✕</button>
         </div>


### PR DESCRIPTION
## Summary
- ensure attachment preview images include descriptive alt text for accessibility

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `CHROME_BIN=chromium-browser npm test -- --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a139cf88325a9f82ec0c2f186df