### PR TITLE
fix: mark areaMap as readonly

### DIFF
--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -21,7 +21,7 @@ export class PostListComponent implements OnDestroy, OnChanges {
   error = false;
   private page = 1;
   private ctx!: ReportContext;
-  private areaMap = new Map<string, number>();
+  private readonly areaMap = new Map<string, number>();
   private readonly destroy$ = new Subject<void>();
 
   constructor(


### PR DESCRIPTION
## Summary
- mark areaMap as readonly in PostListComponent

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a00df7083258a26e1a0a056bdb0