### PR TITLE
refactor: mark destroy stream as readonly

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -30,7 +30,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
   message = '';
   attachments: AttachmentView[] = [];
 
-  private destroy$ = new Subject<void>();
+  private readonly destroy$ = new Subject<void>();
 
   constructor(private repliesService: RepliesService) {}
 


### PR DESCRIPTION
## Summary
- mark `destroy$` subject as `readonly` in ReplyThreadComponent

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless missing: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a2568d88325845c23924bc5c230