### PR TITLE
chore: mark replies service readonly

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -32,7 +32,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private repliesService: RepliesService) {}
+  constructor(private readonly repliesService: RepliesService) {}
 
   ngOnInit(): void {
     this.load();


### PR DESCRIPTION
## Summary
- mark RepliesService injected dependency as readonly to clarify intent

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a385f7883259ea89f9e1a6bf0e9