### PR TITLE
refactor: use optional chaining in reply thread

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -87,7 +87,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
 
   onPaste(evt: ClipboardEvent): void {
     const items = evt.clipboardData?.files;
-    if (items && items.length) this.addFiles(Array.from(items));
+    if (items?.length) this.addFiles(Array.from(items));
   }
 
   private addFiles(files: File[]): void {


### PR DESCRIPTION
## Summary
- simplify clipboard file handling using optional chaining

## Testing
- `npm test --prefix frontend -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a4c8248832586861bcdd5eeed4a