### PR TITLE
refactor: replace ARIA textbox with textarea

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.css
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.css
@@ -1,4 +1,1 @@
-.editor:empty::before {
-  content: attr(data-placeholder);
-  color: #757575; /* mid-gray */
-}
+/* Placeholder is handled natively by the textarea element */

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -75,16 +75,14 @@
       <button type="button" (click)="format('insertOrderedList')" aria-label="Lista numerada" class="px-2 py-1 hover:bg-light-gray">1.</button>
       <button type="button" (click)="formatLink()" aria-label="Link" class="px-2 py-1 hover:bg-light-gray">🔗</button>
     </div>
-    <div
+    <textarea
       #editor
-      class="editor p-2 min-h-[120px] outline-none"
-      contenteditable="true"
-      role="textbox"
+      class="editor p-2 min-h-[120px] outline-none w-full resize-none"
       aria-label="Conteúdo"
-      data-placeholder="Escreva uma atualização do turno… Ex.: status de produção, ocorrências, apontamentos"
+      placeholder="Escreva uma atualização do turno… Ex.: status de produção, ocorrências, apontamentos"
       (input)="saveDraft()"
       (paste)="onPaste($event)"
-    ></div>
+    ></textarea>
   </div>
 
   <div *ngIf="attachments.length" class="space-y-2">


### PR DESCRIPTION
## Summary
- use `<textarea>` for post composer input instead of `div` with `textbox` role
- update formatting logic to wrap selected text and links in textarea
- remove obsolete CSS placeholder style

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09dbc2b4832586bf988ee80fed5a