### PR TITLE
chore: mark areas service readonly

### DIFF
--- a/frontend/src/app/pages/report/post-composer/post-composer.component.ts
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.ts
@@ -29,7 +29,7 @@ export class PostComposerComponent implements OnInit {
 
   constructor(
     private readonly appState: AppStateService,
-    private areasService: AreasService,
+    private readonly areasService: AreasService,
     private readonly posts: PostsService
   ) {}
 


### PR DESCRIPTION
## Summary
- mark AreasService dependency as readonly in PostComposerComponent

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba09ee20f483258f72205d4575337d