### PR TITLE
chore: mark PostsService as readonly

### DIFF
--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -17,7 +17,7 @@ export class ReportComponent {
   otherContext?: ReportContext;
   private areas: Area[] = [];
 
-  constructor(private appState: AppStateService, private posts: PostsService, private areasService: AreasService) {
+  constructor(private readonly appState: AppStateService, private readonly posts: PostsService, private readonly areasService: AreasService) {
     this.areasService.getAreasWithIds().subscribe((areas) => {
       this.areas = areas;
       this.checkDeepLink();


### PR DESCRIPTION
## Summary
- mark PostsService injection in ReportComponent constructor as readonly to reflect immutability
- also mark related injected services as readonly for clarity

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a780a7c8325b8ca8b94636461f6