### PR TITLE
refactor: mark areas service as readonly

### DIFF
--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -17,7 +17,7 @@ export class ReportComponent {
   otherContext?: ReportContext;
   private areas: Area[] = [];
 
-  constructor(private appState: AppStateService, private posts: PostsService, private areasService: AreasService) {
+  constructor(private appState: AppStateService, private posts: PostsService, private readonly areasService: AreasService) {
     this.areasService.getAreasWithIds().subscribe((areas) => {
       this.areas = areas;
       this.checkDeepLink();


### PR DESCRIPTION
## Summary
- mark injected AreasService as readonly since it is not reassigned

## Testing
- `cd frontend && npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a88af2c832591fadc4c3a2fdd15