### PR TITLE
chore: mark appState as readonly

### DIFF
--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -17,7 +17,7 @@ export class ReportComponent {
   otherContext?: ReportContext;
   private areas: Area[] = [];
 
-  constructor(private appState: AppStateService, private posts: PostsService, private areasService: AreasService) {
+  constructor(private readonly appState: AppStateService, private posts: PostsService, private areasService: AreasService) {
     this.areasService.getAreasWithIds().subscribe((areas) => {
       this.areas = areas;
       this.checkDeepLink();


### PR DESCRIPTION
## Summary
- mark `appState` service dependency as `readonly` in `ReportComponent`

## Testing
- `npm test --prefix frontend -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a66848083259ac64fdfb73b6629