### PR TITLE
refactor: use RegExp.exec for deep link parsing

### DIFF
--- a/frontend/src/app/pages/report/report.component.ts
+++ b/frontend/src/app/pages/report/report.component.ts
@@ -25,7 +25,7 @@ export class ReportComponent {
   }
 
   private checkDeepLink(): void {
-    const match = window.location.hash.match(/post-(\d+)/);
+    const match = /post-(\d+)/.exec(window.location.hash);
     if (!match) return;
     const id = Number(match[1]);
     this.posts.get(id).subscribe({


### PR DESCRIPTION
## Summary
- replace String.match with RegExp.exec in report component for deeper link handling

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a9986088325b61cc44c15b2fd72