### PR TITLE
feat: enlarge image attachments

### DIFF
--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -19,10 +19,21 @@
       <span class="text-xs text-mid-gray">{{ post.author.name }} — {{ post.createdAt | date:'dd/MM/yyyy HH:mm' }}</span>
     </div>
     <div class="mt-2 prose prose-sm max-w-none" [innerHTML]="post.content"></div>
-    <div *ngIf="post.attachments.length" class="mt-2 flex flex-wrap gap-2">
+    <div *ngIf="post.attachments.length" class="mt-2 flex flex-col gap-2">
       <ng-container *ngFor="let att of post.attachments">
-        <img *ngIf="att.mimeType.startsWith('image/')" [src]="att.url" [alt]="att.filename" class="w-24 h-24 object-cover border" />
-        <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-hydro-blue text-sm underline">
+        <img
+          *ngIf="att.mimeType.startsWith('image/')"
+          [src]="att.url"
+          [alt]="att.filename"
+          class="max-w-full max-h-96 object-contain border cursor-pointer"
+          (click)="openImage(att.url)"
+        />
+        <a
+          *ngIf="att.mimeType === 'application/pdf'"
+          [href]="att.url"
+          target="_blank"
+          class="flex items-center text-hydro-blue text-sm underline"
+        >
           📄 {{ att.filename }}
         </a>
       </ng-container>
@@ -39,3 +50,15 @@
     <button (click)="loadMore()" class="px-4 py-2 bg-light-gray rounded">Carregar mais</button>
   </div>
 </section>
+<div
+  *ngIf="modalImageUrl"
+  class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
+  (click)="closeImage()"
+>
+  <img
+    [src]="modalImageUrl"
+    alt="Imagem ampliada"
+    class="max-w-[90vw] max-h-[90vh] object-contain"
+    (click)="$event.stopPropagation()"
+  />
+</div>

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -19,6 +19,7 @@ export class PostListComponent implements OnDestroy, OnChanges {
   count = 0;
   loading = true;
   error = false;
+  modalImageUrl?: string;
   private page = 1;
   private ctx!: ReportContext;
   private readonly areaMap = new Map<string, number>();
@@ -101,6 +102,14 @@ export class PostListComponent implements OnDestroy, OnChanges {
   copyLink(post: Post): void {
     const url = `${window.location.pathname}?area=${encodeURIComponent(this.ctx.area)}&date=${this.ctx.date}&shift=${this.ctx.shift}#post-${post.id}`;
     navigator.clipboard.writeText(url);
+  }
+
+  openImage(url: string): void {
+    this.modalImageUrl = url;
+  }
+
+  closeImage(): void {
+    this.modalImageUrl = undefined;
   }
 
   trackById(_: number, item: Post): number {

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -9,9 +9,15 @@
     <article class="mb-2">
       <div class="text-xs text-mid-gray">{{ r.author.name }} — {{ r.createdAt | date:'dd/MM/yyyy HH:mm' }}</div>
       <div class="prose prose-sm max-w-none" [innerHTML]="r.content"></div>
-      <div *ngIf="r.attachments.length" class="mt-1 flex flex-wrap gap-2">
+      <div *ngIf="r.attachments.length" class="mt-1 flex flex-col gap-2">
         <ng-container *ngFor="let att of r.attachments">
-          <img *ngIf="att.mimeType.startsWith('image/')" [src]="att.url" [alt]="att.filename" class="w-16 h-16 object-cover border" />
+          <img
+            *ngIf="att.mimeType.startsWith('image/')"
+            [src]="att.url"
+            [alt]="att.filename"
+            class="max-w-full max-h-96 object-contain border cursor-pointer"
+            (click)="openImage(att.url)"
+          />
           <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-hydro-blue text-sm underline">
             📄 {{ att.filename }}
           </a>
@@ -38,4 +44,16 @@
       <span class="text-sm text-aluminium" *ngIf="message">{{ message }}</span>
     </div>
   </div>
+</div>
+<div
+  *ngIf="modalImageUrl"
+  class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
+  (click)="closeImage()"
+>
+  <img
+    [src]="modalImageUrl"
+    alt="Imagem ampliada"
+    class="max-w-[90vw] max-h-[90vh] object-contain"
+    (click)="$event.stopPropagation()"
+  />
 </div>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -29,6 +29,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
   sending = false;
   message = '';
   attachments: AttachmentView[] = [];
+  modalImageUrl?: string;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -73,6 +74,14 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     if (this.showForm) {
       setTimeout(() => this.editor?.nativeElement.focus());
     }
+  }
+
+  openImage(url: string): void {
+    this.modalImageUrl = url;
+  }
+
+  closeImage(): void {
+    this.modalImageUrl = undefined;
   }
 
   onFileInput(event: Event): void {


### PR DESCRIPTION
## Summary
- display image attachments at their natural size with max constraints
- add modal viewer to expand images when clicked

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0dc8b82c83259005b2e9f20dc9da