### PR TITLE
fix: prevent duplicate reply counts

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -140,10 +140,7 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     this.repliesService
       .create(this.post.id, { content: sanitized, attachments: this.attachments.map((a) => a.file) })
       .subscribe({
-        next: (reply) => {
-          this.replies.push(reply);
-          this.post._count.replies++;
-          this.total++;
+        next: () => {
           this.editor.nativeElement.innerHTML = '';
           this.attachments = [];
           this.showForm = false;


### PR DESCRIPTION
## Summary
- avoid manually pushing new replies and incrementing counters in ReplyThreadComponent

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba1338e9888325bf56c51d8004300b