### PR TITLE
Add delete support for posts and replies

### DIFF
--- a/frontend/src/app/core/posts.service.ts
+++ b/frontend/src/app/core/posts.service.ts
@@ -86,4 +86,9 @@ export class PostsService {
   get(id: number): Observable<Post> {
     return this.http.get<Post>(`${environment.apiUrl}/api/posts/${id}`);
   }
+
+  /** Deletes a post by id. */
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/api/posts/${id}`);
+  }
 }

--- a/frontend/src/app/core/replies.service.ts
+++ b/frontend/src/app/core/replies.service.ts
@@ -48,4 +48,8 @@ export class RepliesService {
       .post<Reply>(`${environment.apiUrl}/api/posts/${postId}/replies`, form)
       .pipe(tap((r) => this.createdSource.next(r)));
   }
+
+  delete(postId: number, id: number): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/api/posts/${postId}/replies/${id}`);
+  }
 }

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -41,6 +41,7 @@
     <div class="mt-2 flex items-center gap-4 text-sm text-aluminium">
       <button class="text-hydro-blue hover:underline" (click)="thread.toggleComposer()">Responder</button>
       <button class="text-hydro-blue hover:underline" (click)="copyLink(post)">Copiar link</button>
+      <button class="text-bauxite hover:underline" (click)="deletePost(post)">Excluir</button>
       <span>{{ post._count.replies }} respostas</span>
       <span>Atualizado {{ post.updatedAt | date:'dd/MM HH:mm' }}</span>
     </div>

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -104,6 +104,17 @@ export class PostListComponent implements OnDestroy, OnChanges {
     navigator.clipboard.writeText(url);
   }
 
+  deletePost(post: Post): void {
+    if (!confirm('Excluir este post?')) return;
+    this.postsService.delete(post.id).subscribe({
+      next: () => {
+        this.posts = this.posts.filter((p) => p.id !== post.id);
+        this.count--;
+      },
+      error: () => alert('Falha ao excluir post.'),
+    });
+  }
+
   openImage(url: string): void {
     this.modalImageUrl = url;
   }

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -23,6 +23,9 @@
           </a>
         </ng-container>
       </div>
+      <div class="mt-1">
+        <button class="text-sm text-bauxite hover:underline" (click)="deleteReply(r)">Excluir</button>
+      </div>
     </article>
   </ng-container>
   <button *ngIf="replies.length < total && !loading" (click)="loadMore()" class="text-sm text-hydro-blue underline">Ver mais respostas</button>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -84,6 +84,18 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     this.modalImageUrl = undefined;
   }
 
+  deleteReply(r: Reply): void {
+    if (!confirm('Excluir esta resposta?')) return;
+    this.repliesService.delete(this.post.id, r.id).subscribe({
+      next: () => {
+        this.replies = this.replies.filter((rr) => rr.id !== r.id);
+        this.post._count.replies--;
+        this.total--;
+      },
+      error: () => alert('Falha ao excluir resposta.'),
+    });
+  }
+
   onFileInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     if (input.files) this.addFiles(Array.from(input.files));


### PR DESCRIPTION
## Summary
- allow deleting posts with attachments and audit logging
- allow deleting replies with audit logging
- expose delete APIs to frontend and add UI actions

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Missing script)*
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `node --check backend/src/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba14d909ac832597a29fb9262be22f