### PR TITLE
Reduz margens e tamanhos para otimizar relatório de turno

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -1,23 +1,23 @@
 <header class="sticky top-0 z-10 bg-white border-b border-light-gray" role="banner">
-  <div class="max-w-[70rem] mx-auto px-4 sm:px-6 lg:px-8 py-3 flex flex-wrap items-center gap-4">
+  <div class="max-w-[70rem] mx-auto px-2 sm:px-4 lg:px-6 py-2 flex flex-wrap items-center gap-2">
     <!-- Logos -->
     <img
       src="assets/brand/hydro/logos/primary/hydro-logo-vertical-blue.png"
       alt="Hydro"
-      class="h-16 w-auto hidden sm:block"
+      class="h-12 w-auto hidden sm:block"
     />
     <img
       src="assets/brand/hydro/logos/secondary/hydro-logo-horizontal-blue.png"
       alt="Hydro"
-      class="h-10 w-auto sm:hidden"
+      class="h-8 w-auto sm:hidden"
     />
 
-    <div class="flex flex-wrap items-center gap-2 ml-auto text-sm font-arial">
+    <div class="flex flex-wrap items-center gap-1 ml-auto text-sm font-arial">
       <!-- Area selector -->
       <label for="area" class="sr-only">Área</label>
       <select
         id="area"
-        class="px-3 py-2 bg-white border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
+        class="px-2 py-1.5 bg-white border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
         [ngModel]="(context$ | async)?.area"
         (ngModelChange)="onAreaChange($event)"
       >
@@ -29,7 +29,7 @@
       <input
         id="date"
         type="date"
-        class="px-3 py-2 bg-white border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
+        class="px-2 py-1.5 bg-white border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue"
         [ngModel]="(context$ | async)?.date"
         (ngModelChange)="onDateChange($event)"
       />
@@ -42,7 +42,7 @@
         *ngIf="context$ | async as ctx"
       >
         <label
-          class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
           [ngClass]="ctx.shift === 1 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
         >
           <input
@@ -58,7 +58,7 @@
           Turno 1
         </label>
         <label
-          class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
           [ngClass]="ctx.shift === 2 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
         >
           <input
@@ -74,7 +74,7 @@
           Turno 2
         </label>
         <label
-          class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+          class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
           [ngClass]="ctx.shift === 3 ? 'bg-hydro-blue text-white hover:bg-hydro-dark-blue' : 'hover:bg-light-gray'"
         >
           <input
@@ -95,7 +95,7 @@
       <button
         type="button"
         (click)="exportPdf()"
-        class="btn btn-primary p-2"
+        class="btn btn-primary p-1.5"
         aria-label="Exportar PDF"
       >
         <svg
@@ -118,12 +118,12 @@
 
       <!-- User placeholder -->
       <div
-        class="w-8 h-8 rounded-full bg-light-gray flex items-center justify-center text-hydro-blue"
+        class="w-7 h-7 rounded-full bg-light-gray flex items-center justify-center text-hydro-blue"
         aria-label="Usuário"
       >
         <span class="text-sm">U</span>
       </div>
     </div>
   </div>
-  <div *ngIf="exportMessage" class="text-center text-sm text-aluminium py-1">{{ exportMessage }}</div>
+  <div *ngIf="exportMessage" class="text-center text-sm text-aluminium py-0.5">{{ exportMessage }}</div>
 </header>

--- a/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
+++ b/frontend/src/app/pages/report/area-indicators/area-indicators.component.html
@@ -1,12 +1,12 @@
-<section class="mt-8 p-6 bg-white border border-light-gray rounded space-y-4">
-  <h2 class="text-xl font-display">Indicadores do Turno</h2>
+<section class="mt-4 p-4 bg-white border border-light-gray rounded space-y-2">
+  <h2 class="text-lg font-display">Indicadores do Turno</h2>
 
   <ng-container *ngIf="(indicators$ | async) as list">
     <ng-container *ngIf="list.length; else empty">
-      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <div *ngFor="let ind of list" class="p-3 border border-light-gray rounded">
+      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div *ngFor="let ind of list" class="p-2 border border-light-gray rounded">
           <div class="font-medium">{{ ind.name }}</div>
-          <div class="text-2xl">
+          <div class="text-xl">
             {{ ind.value !== null ? (ind.value | number:'1.2-2':'pt-BR') : '—' }}
             <span class="text-base">{{ ind.unit }}</span>
           </div>

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.css
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.css
@@ -1,3 +1,3 @@
 :host ::ng-deep .ql-editor {
-  min-height: 120px;
+  min-height: 100px;
 }

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -1,5 +1,5 @@
 <div
-  class="card p-6 space-y-4"
+  class="card p-4 space-y-2"
   (drop)="onDrop($event)"
   (dragover)="$event.preventDefault()"
 >
@@ -9,7 +9,7 @@
     class="flex border border-aluminium rounded-lg overflow-hidden divide-x divide-aluminium text-sm shadow-sm"
   >
     <label
-      class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'ANNOTATION'"
       [class.text-white]="type === 'ANNOTATION'"
       [ngClass]="{
@@ -28,7 +28,7 @@
       Anotação
     </label>
     <label
-      class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'URGENCY'"
       [class.text-white]="type === 'URGENCY'"
       [ngClass]="{
@@ -47,7 +47,7 @@
       Urgência
     </label>
     <label
-      class="px-3 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
+      class="px-2 py-1 cursor-pointer flex-1 text-center transition-colors focus-within:ring-2 focus-within:ring-hydro-light-blue"
       [class.bg-hydro-blue]="type === 'PENDENCY'"
       [class.text-white]="type === 'PENDENCY'"
       [ngClass]="{
@@ -75,19 +75,19 @@
       format="html"
       (ngModelChange)="saveDraft()"
       placeholder="Escreva uma atualização do turno… Ex.: status de produção, ocorrências, apontamentos"
-      class="min-h-[120px]"
+      class="min-h-[100px]"
     ></quill-editor>
   </div>
 
-  <div *ngIf="attachments.length" class="space-y-2">
-    <div *ngFor="let att of attachments" class="flex items-center gap-2">
-      <img *ngIf="att.url" [src]="att.url" alt="Pré-visualização" class="w-16 h-16 object-cover rounded" />
+  <div *ngIf="attachments.length" class="space-y-1">
+    <div *ngFor="let att of attachments" class="flex items-center gap-1">
+      <img *ngIf="att.url" [src]="att.url" alt="Pré-visualização" class="w-14 h-14 object-cover rounded" />
       <span class="text-sm">{{ att.file.name }} ({{ att.file.size / 1024 | number:'1.0-0' }} KB)</span>
       <button type="button" (click)="removeAttachment(att)" class="text-hydro-blue text-sm underline">Remover</button>
     </div>
   </div>
 
-  <div class="flex items-center gap-4">
+  <div class="flex items-center gap-2">
     <label class="cursor-pointer text-hydro-blue flex items-center gap-1 hover:underline">
       <input type="file" multiple class="hidden" (change)="onFileInput($event)" />
       <span>Anexar arquivos</span>

--- a/frontend/src/app/pages/report/post-list/post-list.component.css
+++ b/frontend/src/app/pages/report/post-list/post-list.component.css
@@ -3,8 +3,8 @@
   @apply max-w-full max-h-96 object-contain border cursor-pointer;
 }
 :host ::ng-deep .prose pre {
-  @apply bg-light-gray p-2 rounded overflow-x-auto;
+  @apply bg-light-gray p-1 rounded overflow-x-auto;
 }
 :host ::ng-deep .prose blockquote {
-  @apply pl-4 border-l-4 border-light-gray text-mid-gray;
+  @apply pl-3 border-l-2 border-light-gray text-mid-gray;
 }

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -1,5 +1,5 @@
-<section class="card mt-8 p-6 space-y-4">
-  <h2 class="text-xl font-display">{{ title }} ({{ count }})</h2>
+<section class="card mt-4 p-4 space-y-2">
+  <h2 class="text-lg font-display">{{ title }} ({{ count }})</h2>
   <div *ngIf="loading" class="text-aluminium">Carregando...</div>
   <div *ngIf="error" class="text-bauxite">
     Erro ao carregar.
@@ -11,15 +11,15 @@
   <article
     *ngFor="let post of posts; trackBy: trackById"
     [attr.id]="'post-' + post.id"
-    class="p-4 border border-light-gray rounded-lg shadow-sm" [class.bg-warm]="post.id === highlightId"
-    [class.mt-4]="post !== posts[0]"
+    class="p-3 border border-light-gray rounded-lg shadow-sm" [class.bg-warm]="post.id === highlightId"
+    [class.mt-3]="post !== posts[0]"
   >
     <div class="flex justify-between items-start">
-      <span class="text-xs font-semibold px-2 py-1 rounded" [ngClass]="tagClass()">{{ typeLabel() }}</span>
+      <span class="text-xs font-semibold px-2 py-0.5 rounded" [ngClass]="tagClass()">{{ typeLabel() }}</span>
       <span class="text-xs text-mid-gray">{{ post.author.name }} — {{ post.createdAt | date:'dd/MM/yyyy HH:mm' }}</span>
     </div>
-    <div class="mt-2 prose prose-sm max-w-none" [innerHTML]="post.content" (click)="onContentClick($event)"></div>
-    <div *ngIf="post.attachments.length" class="mt-2 flex flex-col gap-2">
+    <div class="mt-1 prose prose-sm max-w-none" [innerHTML]="post.content" (click)="onContentClick($event)"></div>
+    <div *ngIf="post.attachments.length" class="mt-1 flex flex-col gap-1">
       <ng-container *ngFor="let att of post.attachments">
         <img
           *ngIf="att.mimeType.startsWith('image/')"
@@ -38,7 +38,7 @@
         </a>
       </ng-container>
     </div>
-    <div class="mt-2 flex items-center gap-4 text-sm text-aluminium">
+    <div class="mt-1 flex items-center gap-3 text-sm text-aluminium">
       <button class="text-hydro-blue hover:underline" (click)="thread.toggleComposer()">Responder</button>
       <button class="text-hydro-blue hover:underline" (click)="copyLink(post)">Copiar link</button>
       <button class="text-bauxite hover:underline" (click)="deletePost(post)">Excluir</button>
@@ -47,7 +47,7 @@
     </div>
     <app-reply-thread #thread [post]="post"></app-reply-thread>
   </article>
-  <div *ngIf="!loading && posts.length < count" class="text-center mt-4">
+  <div *ngIf="!loading && posts.length < count" class="text-center mt-2">
     <button (click)="loadMore()" class="btn bg-light-gray hover:bg-light-gray/80">Carregar mais</button>
   </div>
 </section>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.css
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.css
@@ -1,5 +1,5 @@
 :host ::ng-deep .ql-editor {
-  min-height: 80px;
+  min-height: 60px;
 }
 
 :host ::ng-deep .prose img {
@@ -7,9 +7,9 @@
 }
 
 :host ::ng-deep .prose pre {
-  @apply bg-light-gray p-2 rounded overflow-x-auto;
+  @apply bg-light-gray p-1 rounded overflow-x-auto;
 }
 
 :host ::ng-deep .prose blockquote {
-  @apply pl-4 border-l-4 border-light-gray text-mid-gray;
+  @apply pl-3 border-l-2 border-light-gray text-mid-gray;
 }

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -1,4 +1,4 @@
-<div class="mt-2 border-l border-light-gray pl-4">
+<div class="mt-1 border-l border-light-gray pl-3">
   <div *ngIf="loading" class="text-mid-gray">Carregando respostas...</div>
   <div *ngIf="error" class="text-bauxite">
     Falha ao carregar respostas.
@@ -6,10 +6,10 @@
   </div>
   <div *ngIf="!loading && !error && replies.length === 0" class="text-mid-gray">Nenhuma resposta para este post.</div>
   <ng-container *ngFor="let r of replies">
-    <article class="mb-2">
+    <article class="mb-1">
       <div class="text-xs text-mid-gray">{{ r.author.name }} — {{ r.createdAt | date:'dd/MM/yyyy HH:mm' }}</div>
       <div class="prose prose-sm max-w-none" [innerHTML]="r.content" (click)="onContentClick($event)"></div>
-      <div *ngIf="r.attachments.length" class="mt-1 flex flex-col gap-2">
+      <div *ngIf="r.attachments.length" class="mt-1 flex flex-col gap-1">
         <ng-container *ngFor="let att of r.attachments">
           <img
             *ngIf="att.mimeType.startsWith('image/')"
@@ -29,7 +29,7 @@
     </article>
   </ng-container>
   <button *ngIf="replies.length < total && !loading" (click)="loadMore()" class="text-sm text-hydro-blue underline">Ver mais respostas</button>
-  <div *ngIf="showForm" class="mt-2">
+  <div *ngIf="showForm" class="mt-1">
     <div class="border border-light-gray rounded" (drop)="onDrop($event)" (dragover)="$event.preventDefault()" (paste)="onPaste($event)">
       <quill-editor
         #editor
@@ -37,22 +37,22 @@
         [modules]="modules"
         format="html"
         placeholder="Escreva uma resposta..."
-        class="min-h-[80px]"
+        class="min-h-[60px]"
       ></quill-editor>
     </div>
-    <input type="file" multiple (change)="onFileInput($event)" class="mt-2" />
-    <div *ngIf="attachments.length" class="mt-2 flex flex-wrap gap-2">
+    <input type="file" multiple (change)="onFileInput($event)" class="mt-1" />
+    <div *ngIf="attachments.length" class="mt-1 flex flex-wrap gap-1">
       <ng-container *ngFor="let att of attachments">
         <div class="relative">
-          <img *ngIf="att.url" [src]="att.url" [alt]="att.file.name" class="w-16 h-16 object-cover border border-light-gray" />
+          <img *ngIf="att.url" [src]="att.url" [alt]="att.file.name" class="w-14 h-14 object-cover border border-light-gray" />
           <span *ngIf="!att.url" class="text-xs">{{ att.file.name }}</span>
           <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-hydro-blue bg-white">✕</button>
         </div>
       </ng-container>
     </div>
-    <div class="mt-2 flex items-center gap-2">
-      <button (click)="send()" [disabled]="sending" class="px-3 py-1 bg-hydro-blue hover:bg-hydro-dark-blue text-white rounded">Enviar</button>
-      <button (click)="toggleComposer()" class="px-3 py-1">Cancelar</button>
+    <div class="mt-1 flex items-center gap-1">
+      <button (click)="send()" [disabled]="sending" class="px-2 py-1 bg-hydro-blue hover:bg-hydro-dark-blue text-white rounded">Enviar</button>
+      <button (click)="toggleComposer()" class="px-2 py-1">Cancelar</button>
       <span class="text-sm text-aluminium" *ngIf="message">{{ message }}</span>
     </div>
   </div>

--- a/frontend/src/app/pages/report/report.component.html
+++ b/frontend/src/app/pages/report/report.component.html
@@ -1,7 +1,7 @@
-<div class="max-w-[70rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">
+<div class="max-w-[70rem] mx-auto px-2 sm:px-4 lg:px-6 py-4 space-y-6">
   <div>
-    <h1 class="text-3xl font-display text-black">Relatório de Turno</h1>
-    <p *ngIf="context$ | async as ctx" class="mt-2 text-aluminium font-arial">
+    <h1 class="text-2xl font-display text-black">Relatório de Turno</h1>
+    <p *ngIf="context$ | async as ctx" class="mt-1 text-aluminium font-arial">
       {{ ctx.area }} — {{ ctx.date | date:'dd/MM/yyyy' }} — Turno {{ ctx.shift }}
     </p>
   </div>
@@ -11,7 +11,7 @@
   </section>
 
   <app-area-indicators id="area-indicators"></app-area-indicators>
-  <div *ngIf="otherContext" class="p-4 bg-warm border border-aluminium rounded">
+  <div *ngIf="otherContext" class="p-3 bg-warm border border-aluminium rounded">
     Post pertencente a outro contexto.
     <button (click)="changeContext()" class="text-hydro-blue underline">Ajustar contexto</button>
   </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -68,7 +68,7 @@
 /* Componentes customizados com Tailwind */
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors duration-200 shadow-sm hover:shadow focus:outline-none focus:ring-2 focus:ring-offset-2;
+    @apply inline-flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg font-medium transition-colors duration-200 shadow-sm hover:shadow focus:outline-none focus:ring-2 focus:ring-offset-2;
   }
 
   .btn-primary {
@@ -84,10 +84,10 @@
   }
 
   .card-header {
-    @apply bg-gradient-to-r from-hydro-blue to-hydro-light-blue text-white p-6 text-center;
+    @apply bg-gradient-to-r from-hydro-blue to-hydro-light-blue text-white p-4 text-center;
   }
 
   .input {
-    @apply w-full px-3 py-2 border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue focus:border-transparent;
+    @apply w-full px-2 py-1.5 border border-aluminium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-hydro-light-blue focus:border-transparent;
   }
 }


### PR DESCRIPTION
## Summary
- Compact header layout with smaller controls and logos
- Rework report page components with reduced padding and font sizes to maximize screen usage
- Adjust global styles and button/input spacing for a denser interface

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1ce099408325acb4b0dac4ae50da