### PR TITLE
chore: enlarge header logo and stretch editor width

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -4,12 +4,12 @@
     <img
       src="assets/brand/hydro/logos/primary/hydro-logo-vertical-blue.png"
       alt="Hydro"
-      class="h-12 w-auto hidden sm:block"
+      class="h-16 w-auto hidden sm:block"
     />
     <img
       src="assets/brand/hydro/logos/secondary/hydro-logo-horizontal-blue.png"
       alt="Hydro"
-      class="h-8 w-auto sm:hidden"
+      class="h-12 w-auto sm:hidden"
     />
 
     <div class="flex flex-wrap items-center gap-1 ml-auto text-sm font-arial" *ngIf="context$ | async as ctx">

--- a/frontend/src/app/pages/report/post-composer/post-composer.component.html
+++ b/frontend/src/app/pages/report/post-composer/post-composer.component.html
@@ -67,7 +67,7 @@
     </label>
   </div>
 
-  <div class="border border-light-gray rounded-lg shadow-sm" (paste)="onPaste($event)">
+  <div class="w-full border border-light-gray rounded-lg shadow-sm" (paste)="onPaste($event)">
     <quill-editor
       #editor
       [(ngModel)]="content"
@@ -75,7 +75,7 @@
       format="html"
       (ngModelChange)="saveDraft()"
       placeholder="Escreva uma atualização do turno… Ex.: status de produção, ocorrências, apontamentos"
-      class="min-h-[100px]"
+      class="min-h-[100px] w-full"
     ></quill-editor>
   </div>
 

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -30,14 +30,14 @@
   </ng-container>
   <button *ngIf="replies.length < total && !loading" (click)="loadMore()" class="text-sm text-hydro-blue underline">Ver mais respostas</button>
   <div *ngIf="showForm" class="mt-1">
-    <div class="border border-light-gray rounded" (drop)="onDrop($event)" (dragover)="$event.preventDefault()" (paste)="onPaste($event)">
+    <div class="w-full border border-light-gray rounded" (drop)="onDrop($event)" (dragover)="$event.preventDefault()" (paste)="onPaste($event)">
       <quill-editor
         #editor
         [(ngModel)]="content"
         [modules]="modules"
         format="html"
         placeholder="Escreva uma resposta..."
-        class="min-h-[60px]"
+        class="min-h-[60px] w-full"
       ></quill-editor>
     </div>
     <input type="file" multiple (change)="onFileInput($event)" class="mt-1" />


### PR DESCRIPTION
## Summary
- enlarge Hydro logo in header for better visibility
- allow post and reply editors to span full width

## Testing
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module '@tailwindcss/typography'; Cannot find module 'ngx-quill')*


------
https://chatgpt.com/codex/tasks/task_e_68ba2799fa708325a77a07eba85318e8