### PR TITLE
refactor: mark export service as readonly

### DIFF
--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -17,7 +17,7 @@ export class HeaderComponent implements OnInit {
   constructor(
       private readonly appState: AppStateService,
       private readonly areasService: AreasService,
-      private exportService: ExportService,
+      private readonly exportService: ExportService,
       private readonly notify: NotificationService
     ) {}
 


### PR DESCRIPTION
## Summary
- mark header exportService dependency as readonly

## Testing
- `cd frontend && npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bad38d10b88325993d2f7453696ec6