### PR TITLE
fix: wrap delete confirmation block in reply thread component

### DIFF
--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -101,17 +101,20 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
   }
 
   deleteReply(r: Reply): void {
-    if (!confirm('Excluir esta resposta?')) return;
-      this.repliesService.delete(this.post.id, r.id).subscribe({
-        next: () => {
-          this.replies = this.replies.filter((rr) => rr.id !== r.id);
-          this.post._count.replies--;
-          this.total--;
-          this.notify.success('Resposta excluída.');
-        },
-        error: () => this.notify.error('Falha ao excluir resposta.'),
-      });
+    if (!confirm('Excluir esta resposta?')) {
+      return;
     }
+
+    this.repliesService.delete(this.post.id, r.id).subscribe({
+      next: () => {
+        this.replies = this.replies.filter((rr) => rr.id !== r.id);
+        this.post._count.replies--;
+        this.total--;
+        this.notify.success('Resposta excluída.');
+      },
+      error: () => this.notify.error('Falha ao excluir resposta.'),
+    });
+  }
 
   onFileInput(event: Event): void {
     const input = event.target as HTMLInputElement;


### PR DESCRIPTION
## Summary
- ensure delete action runs only when confirmation is accepted by wrapping block in braces

## Testing
- `npm test --prefix frontend -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68bad46aa75c8325b943edef3de3537d