### PR TITLE
fix: improve modal image alt text

### DIFF
--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -26,7 +26,7 @@
           [src]="att.url"
           [alt]="att.filename"
           class="max-w-full max-h-96 object-contain border cursor-pointer"
-          (click)="openImage(att.url)"
+          (click)="openImage(att.url, att.filename)"
         />
         <a
           *ngIf="att.mimeType === 'application/pdf'"
@@ -58,7 +58,7 @@
 >
   <img
     [src]="modalImageUrl"
-    alt="Imagem ampliada"
+    [alt]="modalImageAlt"
     class="max-w-[90vw] max-h-[90vh] object-contain"
     (click)="$event.stopPropagation()"
   />

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -21,6 +21,7 @@ export class PostListComponent implements OnDestroy, OnChanges {
   loading = true;
   error = false;
   modalImageUrl?: string;
+  modalImageAlt?: string;
   private page = 1;
   private ctx!: ReportContext;
   private readonly areaMap = new Map<string, number>();
@@ -118,18 +119,20 @@ export class PostListComponent implements OnDestroy, OnChanges {
       });
     }
 
-  openImage(url: string): void {
+  openImage(url: string, alt: string): void {
     this.modalImageUrl = url;
+    this.modalImageAlt = alt;
   }
 
   closeImage(): void {
     this.modalImageUrl = undefined;
+    this.modalImageAlt = undefined;
   }
 
   onContentClick(event: Event): void {
     const target = event.target as HTMLElement;
     if (target instanceof HTMLImageElement) {
-      this.openImage(target.src);
+      this.openImage(target.src, target.alt);
     }
   }
 

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -16,7 +16,7 @@
             [src]="att.url"
             [alt]="att.filename"
             class="max-w-full max-h-96 object-contain border cursor-pointer"
-            (click)="openImage(att.url)"
+            (click)="openImage(att.url, att.filename)"
           />
           <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-hydro-blue text-sm underline">
             📄 {{ att.filename }}
@@ -63,7 +63,7 @@
 >
   <img
     [src]="modalImageUrl"
-    alt="Imagem ampliada"
+    [alt]="modalImageAlt"
     class="max-w-[90vw] max-h-[90vh] object-contain"
     (click)="$event.stopPropagation()"
   />

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -29,9 +29,10 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
   total = 0;
   showForm = false;
   sending = false;
-    attachments: AttachmentView[] = [];
-    modalImageUrl?: string;
-    content = '';
+  attachments: AttachmentView[] = [];
+  modalImageUrl?: string;
+  modalImageAlt?: string;
+  content = '';
     modules = {
     toolbar: [
       ['bold', 'italic', 'underline', 'strike'],
@@ -85,18 +86,20 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     }
   }
 
-  openImage(url: string): void {
+  openImage(url: string, alt: string): void {
     this.modalImageUrl = url;
+    this.modalImageAlt = alt;
   }
 
   closeImage(): void {
     this.modalImageUrl = undefined;
+    this.modalImageAlt = undefined;
   }
 
   onContentClick(event: Event): void {
     const target = event.target as HTMLElement;
     if (target instanceof HTMLImageElement) {
-      this.openImage(target.src);
+      this.openImage(target.src, target.alt);
     }
   }
 


### PR DESCRIPTION
## Summary
- capture source image alt text and reuse in modal
- replace hardcoded "Imagem ampliada" with dynamic alt binding

## Testing
- `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68bad4c297148325a03de2658ecd0805