### PR TITLE
feat: improve keyboard accessibility

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -42,7 +42,7 @@
           <li
             *ngFor="let area of areas"
             (click)="selectArea(area.name)"
-            (keydown.enter)="selectArea(area.name)"
+            (keydown)="onAreaKeydown($event, area.name)"
             tabindex="0"
             class="px-3 py-1.5 cursor-pointer transition-colors hover:bg-hydro-light-blue hover:text-white"
             [ngClass]="{ 'bg-hydro-blue text-white hover:bg-hydro-dark-blue': ctx.area === area.name }"

--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -46,6 +46,13 @@ export class HeaderComponent implements OnInit {
     this.areaDropdownOpen = false;
   }
 
+  onAreaKeydown(event: KeyboardEvent, area: string): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.selectArea(area);
+    }
+  }
+
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: Event): void {
     const target = event.target as HTMLElement;

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -18,7 +18,13 @@
       <span class="text-xs font-semibold px-2 py-0.5 rounded" [ngClass]="tagClass()">{{ typeLabel() }}</span>
       <span class="text-xs text-mid-gray">{{ post.author.name }} — {{ post.createdAt | date:'dd/MM/yyyy HH:mm' }}</span>
     </div>
-    <div class="mt-1 prose prose-sm max-w-none" [innerHTML]="post.content" (click)="onContentClick($event)"></div>
+    <div
+      class="mt-1 prose prose-sm max-w-none"
+      [innerHTML]="post.content"
+      (click)="onContentClick($event)"
+      tabindex="0"
+      (keydown)="onContentKeydown($event)"
+    ></div>
     <div *ngIf="post.attachments.length" class="mt-1 flex flex-col gap-1">
       <ng-container *ngFor="let att of post.attachments">
         <img
@@ -27,6 +33,8 @@
           [alt]="att.filename"
           class="max-w-full max-h-96 object-contain border cursor-pointer"
           (click)="openImage(att.url, att.filename)"
+          tabindex="0"
+          (keydown.enter)="openImage(att.url, att.filename)"
         />
         <a
           *ngIf="att.mimeType === 'application/pdf'"
@@ -55,6 +63,8 @@
   *ngIf="modalImageUrl"
   class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
   (click)="closeImage()"
+  tabindex="0"
+  (keydown)="onModalKeydown($event)"
 >
   <img
     [src]="modalImageUrl"

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -136,6 +136,18 @@ export class PostListComponent implements OnDestroy, OnChanges {
     }
   }
 
+  onContentKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      this.onContentClick(event);
+    }
+  }
+
+  onModalKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.closeImage();
+    }
+  }
+
   trackById(_: number, item: Post): number {
     return item.id;
   }


### PR DESCRIPTION
## Summary
- handle keyboard interactions in area dropdown
- enable keyboard access for post attachments and modal

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68bad6d987548325b072624e0b68cb08