### PR TITLE
fix: resolve accessibility lint warnings

### DIFF
--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -39,15 +39,16 @@
           *ngIf="areaDropdownOpen"
           class="absolute left-0 mt-1 w-full max-h-60 overflow-auto bg-white border border-aluminium rounded-lg shadow-lg z-20"
         >
-          <li
-            *ngFor="let area of areas"
-            (click)="selectArea(area.name)"
-            (keydown)="onAreaKeydown($event, area.name)"
-            tabindex="0"
-            class="px-3 py-1.5 cursor-pointer transition-colors hover:bg-hydro-light-blue hover:text-white"
-            [ngClass]="{ 'bg-hydro-blue text-white hover:bg-hydro-dark-blue': ctx.area === area.name }"
-          >
-            {{ area.name }}
+          <li *ngFor="let area of areas">
+            <button
+              type="button"
+              (click)="selectArea(area.name)"
+              (keydown)="onAreaKeydown($event, area.name)"
+              class="w-full text-left px-3 py-1.5 cursor-pointer transition-colors hover:bg-hydro-light-blue hover:text-white"
+              [ngClass]="{ 'bg-hydro-blue text-white hover:bg-hydro-dark-blue': ctx.area === area.name }"
+            >
+              {{ area.name }}
+            </button>
           </li>
         </ul>
       </div>

--- a/frontend/src/app/pages/report/post-list/post-list.component.html
+++ b/frontend/src/app/pages/report/post-list/post-list.component.html
@@ -22,8 +22,6 @@
       class="mt-1 prose prose-sm max-w-none"
       [innerHTML]="post.content"
       (click)="onContentClick($event)"
-      tabindex="0"
-      (keydown)="onContentKeydown($event)"
     ></div>
     <div *ngIf="post.attachments.length" class="mt-1 flex flex-col gap-1">
       <ng-container *ngFor="let att of post.attachments">
@@ -33,8 +31,6 @@
           [alt]="sanitizeAlt(att.filename)"
           class="max-w-full max-h-96 object-contain border cursor-pointer"
           (click)="openImage(att.url, sanitizeAlt(att.filename))"
-          tabindex="0"
-          (keydown.enter)="openImage(att.url, sanitizeAlt(att.filename))"
         />
         <a
           *ngIf="att.mimeType === 'application/pdf'"
@@ -59,12 +55,11 @@
     <button (click)="loadMore()" class="btn bg-light-gray hover:bg-light-gray/80">Carregar mais</button>
   </div>
 </section>
-<div
+<button
   *ngIf="modalImageUrl"
+  type="button"
   class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
   (click)="closeImage()"
-  tabindex="0"
-  role="button"
   (keydown)="onModalKeydown($event)"
 >
   <img
@@ -72,7 +67,5 @@
     [alt]="modalImageAlt"
     class="max-w-[90vw] max-h-[90vh] object-contain"
     (click)="$event.stopPropagation()"
-    tabindex="0"
-    (keydown.enter)="$event.stopPropagation()"
   />
-</div>
+</button>

--- a/frontend/src/app/pages/report/post-list/post-list.component.ts
+++ b/frontend/src/app/pages/report/post-list/post-list.component.ts
@@ -138,12 +138,6 @@ export class PostListComponent implements OnDestroy, OnChanges {
     }
   }
 
-  onContentKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.onContentClick(event);
-    }
-  }
-
   onModalKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       this.closeImage();

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.html
@@ -12,8 +12,6 @@
         class="prose prose-sm max-w-none"
         [innerHTML]="r.content"
         (click)="onContentClick($event)"
-        tabindex="0"
-        (keydown)="onContentKeydown($event)"
       ></div>
       <div *ngIf="r.attachments.length" class="mt-1 flex flex-col gap-1">
         <ng-container *ngFor="let att of r.attachments">
@@ -23,8 +21,6 @@
             [alt]="sanitizeAlt(att.filename)"
             class="max-w-full max-h-96 object-contain border cursor-pointer"
             (click)="openImage(att.url, sanitizeAlt(att.filename))"
-            tabindex="0"
-            (keydown.enter)="openImage(att.url, sanitizeAlt(att.filename))"
           />
           <a *ngIf="att.mimeType === 'application/pdf'" [href]="att.url" target="_blank" class="flex items-center text-hydro-blue text-sm underline">
             📄 {{ att.filename }}
@@ -52,7 +48,12 @@
     <div *ngIf="attachments.length" class="mt-1 flex flex-wrap gap-1">
       <ng-container *ngFor="let att of attachments">
         <div class="relative">
-          <img *ngIf="att.url" [src]="att.url" [alt]="att.file.name" class="w-14 h-14 object-cover border border-light-gray" />
+          <img
+            *ngIf="att.url"
+            [src]="att.url"
+            [alt]="sanitizeAlt(att.file.name)"
+            class="w-14 h-14 object-cover border border-light-gray"
+          />
           <span *ngIf="!att.url" class="text-xs">{{ att.file.name }}</span>
           <button (click)="removeAttachment(att)" aria-label="Remover" class="absolute top-0 right-0 text-hydro-blue bg-white">✕</button>
         </div>
@@ -64,11 +65,11 @@
     </div>
   </div>
 </div>
-<div
+<button
   *ngIf="modalImageUrl"
+  type="button"
   class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
   (click)="closeImage()"
-  tabindex="0"
   (keydown)="onModalKeydown($event)"
 >
   <img
@@ -76,7 +77,5 @@
     [alt]="modalImageAlt"
     class="max-w-[90vw] max-h-[90vh] object-contain"
     (click)="$event.stopPropagation()"
-    tabindex="0"
-    (keydown.enter)="$event.stopPropagation()"
   />
-</div>
+</button>

--- a/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
+++ b/frontend/src/app/pages/report/reply-thread/reply-thread.component.ts
@@ -103,12 +103,6 @@ export class ReplyThreadComponent implements OnInit, OnDestroy {
     }
   }
 
-  onContentKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.onContentClick(event);
-    }
-  }
-
   onModalKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       this.closeImage();


### PR DESCRIPTION
## Summary
- drop tabIndex on non-interactive elements and use buttons for modal overlays
- sanitize attachment alt text
- replace area dropdown items with buttons

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68badd77a01483259ec224b15028c7ce