### PR TITLE
Document API endpoints in Swagger

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -29,8 +29,18 @@ const swaggerOptions = {
       title: 'Relatório de Turno API',
       version: '1.0.0',
     },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+      },
+    ],
   },
-  apis: [path.join(__dirname, '*.js')],
+  // Include all route files so swagger-jsdoc can parse the annotations and
+  // generate the OpenAPI specification automatically.
+  apis: [
+    path.join(__dirname, '*.js'),
+    path.join(__dirname, 'routes', '*.js'),
+  ],
 };
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/backend/src/routes/areas.js
+++ b/backend/src/routes/areas.js
@@ -4,6 +4,16 @@ const { parseNumberParam } = require('../utils');
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/areas:
+ *   get:
+ *     summary: Lista todas as áreas disponíveis
+ *     tags: [Áreas]
+ *     responses:
+ *       200:
+ *         description: Lista de áreas
+ */
 router.get('/', async (req, res) => {
   try {
     const areas = await prisma.area.findMany();
@@ -14,6 +24,24 @@ router.get('/', async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/areas/{areaId}/indicators:
+ *   get:
+ *     summary: Obtém os indicadores de uma área específica
+ *     tags: [Áreas]
+ *     parameters:
+ *       - in: path
+ *         name: areaId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Lista de indicadores
+ *       400:
+ *         description: Invalid area id
+ */
 router.get('/:areaId/indicators', async (req, res) => {
   const areaId = parseNumberParam(req.params.areaId);
   if (areaId === undefined) {

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -14,6 +14,154 @@ const {
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Posts
+ *   description: Endpoints de gerenciamento de posts e respostas
+ */
+
+/**
+ * @swagger
+ * /api/posts:
+ *   post:
+ *     summary: Cria um novo post
+ *     tags: [Posts]
+ *     responses:
+ *       201:
+ *         description: Post criado com sucesso
+ *       400:
+ *         description: Parâmetros inválidos
+ *   get:
+ *     summary: Lista posts
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: query
+ *         name: areaId
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: query
+ *         name: shift
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Lista de posts
+ */
+
+/**
+ * @swagger
+ * /api/posts/{id}:
+ *   get:
+ *     summary: Obtém um post específico
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Post encontrado
+ *       404:
+ *         description: Post não encontrado
+ *   delete:
+ *     summary: Remove um post
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Post removido
+ *       404:
+ *         description: Post não encontrado
+ */
+
+/**
+ * @swagger
+ * /api/posts/{id}/replies:
+ *   post:
+ *     summary: Adiciona uma resposta a um post
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       201:
+ *         description: Resposta criada
+ *       400:
+ *         description: Parâmetros inválidos
+ *   get:
+ *     summary: Lista respostas de um post
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Lista de respostas
+ */
+
+/**
+ * @swagger
+ * /api/posts/{postId}/replies/{id}:
+ *   delete:
+ *     summary: Remove uma resposta de um post
+ *     tags: [Posts]
+ *     parameters:
+ *       - in: path
+ *         name: postId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Resposta removida
+ *       404:
+ *         description: Resposta não encontrada
+ */
+
 // Create post
 router.post('/', upload.array('attachments'), async (req, res) => {
   try {

--- a/backend/src/routes/profile.js
+++ b/backend/src/routes/profile.js
@@ -3,6 +3,18 @@ const { ensureUser, parseNumberParam } = require('../utils');
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/me:
+ *   get:
+ *     summary: Retorna informações do usuário autenticado
+ *     tags: [Perfil]
+ *     responses:
+ *       200:
+ *         description: Dados do usuário
+ *       500:
+ *         description: Erro ao buscar usuário
+ */
 router.get('/me', async (req, res) => {
   try {
     const userId = parseNumberParam(req.header('x-user-id')) || 1;

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -13,6 +13,25 @@ const {
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Relatórios
+ *   description: Geração e consulta de relatórios
+ */
+
+/**
+ * @swagger
+ * /api/reports:
+ *   get:
+ *     summary: Lista relatórios salvos
+ *     tags: [Relatórios]
+ *     responses:
+ *       200:
+ *         description: Lista de relatórios
+ *       500:
+ *         description: Erro ao buscar relatórios
+ */
 router.get('/reports', async (req, res) => {
   try {
     const reports = await prisma.report.findMany();
@@ -23,6 +42,32 @@ router.get('/reports', async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/indicator-values:
+ *   get:
+ *     summary: Busca valores de indicadores
+ *     tags: [Relatórios]
+ *     parameters:
+ *       - in: query
+ *         name: areaId
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: query
+ *         name: shift
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Valores encontrados
+ *       400:
+ *         description: Parâmetros inválidos
+ */
 router.get('/indicator-values', async (req, res) => {
   const { areaId, date, shift } = req.query;
   const area = parseNumberParam(areaId);
@@ -47,6 +92,30 @@ router.get('/indicator-values', async (req, res) => {
   res.json(values);
 });
 
+/**
+ * @swagger
+ * /api/summary:
+ *   get:
+ *     summary: Resumo de posts por tipo
+ *     tags: [Relatórios]
+ *     parameters:
+ *       - in: query
+ *         name: areaId
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: query
+ *         name: shift
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Resumo retornado
+ */
 router.get('/summary', async (req, res) => {
   const { areaId, date, shift } = req.query;
   const area = parseNumberParam(areaId);
@@ -63,6 +132,20 @@ router.get('/summary', async (req, res) => {
   res.json(counts);
 });
 
+/**
+ * @swagger
+ * /api/export:
+ *   post:
+ *     summary: Gera um relatório em PDF
+ *     tags: [Relatórios]
+ *     responses:
+ *       200:
+ *         description: PDF gerado
+ *       400:
+ *         description: Parâmetros inválidos
+ *       500:
+ *         description: Falha ao gerar PDF
+ */
 router.post('/export', async (req, res) => {
   const { areaId, date, shift } = req.body;
   const userId = parseNumberParam(req.header('x-user-id')) || 1;


### PR DESCRIPTION
## Summary
- configure swagger-jsdoc to load route files and set server information
- add Swagger annotations for areas, posts, profile and report routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb1262bd9c8325b630a4ca53321d92