### PR TITLE
fix: ensure vercel deployment works with db attachments

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
     "build": "echo 'Build não necessário para Node.js'",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.15.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,7 +17,7 @@ const app = express();
 
 // Build allowed origins from env and sensible defaults
 function buildAllowedOrigins() {
-  const defaults = ['http://localhost:4200'];
+  const defaults = ['http://localhost:4200', 'https://relatorio-turno-frontend.vercel.app'];
   const envList = (process.env.CORS_ORIGINS || '')
     .split(',')
     .map((s) => s.trim())

--- a/backend/src/routes/attachments.js
+++ b/backend/src/routes/attachments.js
@@ -15,7 +15,8 @@ router.get('/attachments/:id', async (req, res) => {
   // For non-images, suggest download; for images, show inline
   const disposition = att.mimeType && att.mimeType.startsWith('image/') ? 'inline' : 'attachment';
   res.setHeader('Content-Disposition', `${disposition}; filename="${att.filename}"`);
-  res.send(att.data);
+  // Ensure the response sends a Node.js Buffer
+  res.send(Buffer.from(att.data));
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- run `prisma generate` during install so Vercel builds Prisma client
- allow deployed frontend domain in CORS defaults
- return attachment data using Node.js Buffer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb294581dc8325991d49c81994ad4d