### PR TITLE
Fix Swagger docs on Vercel

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "relatorio-turno-backend",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.15.0",
@@ -19,8 +20,7 @@
         "multer": "^2.0.2",
         "pdfkit": "^0.15.2",
         "sanitize-html": "^2.17.0",
-        "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1"
+        "swagger-jsdoc": "^6.2.8"
       },
       "devDependencies": {
         "nodemon": "^3.0.1",
@@ -161,13 +161,6 @@
       "dependencies": {
         "@prisma/debug": "6.15.0"
       }
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -2799,30 +2792,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.28.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.28.1.tgz",
-      "integrity": "sha512-IvPrtNi8MvjiuDgoSmPYgg27Lvu38fnLD1OSd8Y103xXsPAqezVNnNeHnVCZ/d+CMXJblflGaIyHxAYIF3O71w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
-      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tiny-inflate": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,17 +12,16 @@
   },
   "dependencies": {
     "@prisma/client": "^6.15.0",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
+    "errorhandler": "^1.5.1",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "multer": "^2.0.2",
     "pdfkit": "^0.15.2",
     "sanitize-html": "^2.17.0",
-    "compression": "^1.8.1",
-    "express-async-errors": "^3.1.1",
-    "errorhandler": "^1.5.1",
-    "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
     "nodemon": "^3.0.1",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,7 +3,6 @@ const cors = require('cors');
 const path = require('path');
 const compression = require('compression');
 const swaggerJsdoc = require('swagger-jsdoc');
-const swaggerUi = require('swagger-ui-express');
 const errorhandler = require('errorhandler');
 const { uploadDir } = require('./middleware/upload');
 
@@ -64,7 +63,29 @@ const swaggerOptions = {
   ],
 };
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.get('/swagger.json', (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.send(swaggerSpec);
+});
+app.get('/docs', (req, res) => {
+  res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Relatório de Turno API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.onload = () => {
+      SwaggerUIBundle({ url: '/swagger.json', dom_id: '#swagger-ui' });
+    };
+  </script>
+</body>
+</html>`);
+});
 
 app.get('/', (req, res) => {
   res.json({ message: 'Backend Node.js + Express funcionando!' });

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     { "source": "/", "destination": "/api/index.js" },
     { "source": "/docs", "destination": "/api/index.js" },
-    { "source": "/docs/(.*)", "destination": "/api/index.js" }
+    { "source": "/swagger.json", "destination": "/api/index.js" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- serve Swagger UI using CDN assets and expose `/swagger.json`
- adjust Vercel rewrites for docs and spec
- remove unused swagger-ui-express dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2c390e04832593b44a25c8b46840